### PR TITLE
Add an argument for snapshot buffer

### DIFF
--- a/hftbacktest/data/utils/tardis.py
+++ b/hftbacktest/data/utils/tardis.py
@@ -11,6 +11,7 @@ def convert(
         input_files: List[str],
         output_filename: Optional[str] = None,
         buffer_size: int = 100_000_000,
+        ss_buffer_size: int = 1_000,
         base_latency: float = 0,
         method: Literal['separate', 'adjust'] = 'separate'
 ) -> NDArray:
@@ -91,8 +92,8 @@ def convert(
                         # Prepare to insert DEPTH_SNAPSHOT_EVENT
                         if not is_snapshot:
                             is_snapshot = True
-                            ss_bid = np.empty((1000, 6), np.float64)
-                            ss_ask = np.empty((1000, 6), np.float64)
+                            ss_bid = np.empty((ss_buffer_size, 6), np.float64)
+                            ss_ask = np.empty((ss_buffer_size, 6), np.float64)
                             ss_bid_rn = 0
                             ss_ask_rn = 0
                         if cols[5] == 'bid':


### PR DESCRIPTION
# Problem
The buffer size for the orderbook snapshot in tardis.py was hard-coded and too small for handling recent data. This issue was discovered while processing the data of 2023/06/01. Here's the code snippet that reproduces the issue:
```python
import numpy as np
from hftbacktest.data.utils import tardis

data = tardis.convert(['BTCUSDT_trades_20230601.csv.gz', 'BTCUSDT_book_20230601.csv.gz'])
np.savez('btcusdt_20230601.npz', data=data)
```
This code leads to

```
    107         ss_bid_rn += 1
    108     else:
--> 109         ss_ask[ss_ask_rn] = [
    110             4,
    111             int(cols[2]),
    112             int(cols[3]),
    113             -1,
    114             float(cols[6]),
    115             float(cols[7])
    116         ]
    117         ss_ask_rn += 1
    118 else:

IndexError: index 1000 is out of bounds for axis 0 with size 1000
```

# Solution
This PR introduces an additional parameter ss_buffer_size to tardis.convert function to allow users to set a custom buffer size. The change allows the function to handle a larger data set. The modified code snippet is:
```python
data = tardis.convert(['BTCUSDT_trades_20230601.csv.gz', 'BTCUSDT_book_20230601.csv.gz'], buffer_size=1_000_000_000, ss_buffer_size=2000)
np.savez('btcusdt_20230601.npz', data=data)
```

# Changes
Added a new parameter ss_buffer_size to the function tardis.convert.

# Testing
The code has been tested with recent larger data sets and confirmed to work as expected.

