### PR TITLE
Fix order sequence error due to delays

### DIFF
--- a/hftbacktest/order.py
+++ b/hftbacktest/order.py
@@ -131,6 +131,12 @@ class OrderBus:
     def append(self, order, timestamp):
         timestamp = int(timestamp)
 
+        # Prevents the order sequence from being out of order.
+        if len(self.order_list) > 0:
+            _, latest_timestamp = self.order_list[-1]
+            if timestamp < latest_timestamp:
+                timestamp = latest_timestamp
+
         self.order_list.append((order, timestamp))
 
         if order.order_id in self.orders:


### PR DESCRIPTION
Fix #48 
To prevent the order sequence from being out of order due to latency, this fix enforces that timestamp should be greater than the timestamp of the last queued order.