### PR TITLE
refactor(rust): remove the `Q` generic type dependency in `Order`.

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ bybit = ["serde", "serde_json", "tokio-tungstenite", "reqwest", "sha2", "hmac", 
 tracing = "0.1.40"
 anyhow = "1.0.79"
 thiserror = "1.0.57"
+dyn-clone = "1.0.17"
 chrono = { version = "0.4.33", optional = true }
 serde = { version = "1.0.196", features = ["derive"], optional = true }
 serde_json = { version = "1.0.113", optional = true }
@@ -46,7 +47,6 @@ uuid = { version = "1.8.0", features = ["v4"], optional = true }
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [] }
 clap = { version = "4.5.4", features = ["derive"] }
-polars = "0.40.0"
 
 [profile.dev]
 opt-level = 0

--- a/rust/src/backtest/models/latencies.rs
+++ b/rust/src/backtest/models/latencies.rs
@@ -12,10 +12,10 @@ use crate::{
 /// Provides the order entry latency and the order response latency.
 pub trait LatencyModel {
     /// Returns the order entry latency for the given timestamp and order.
-    fn entry<Q: Clone>(&mut self, timestamp: i64, order: &Order<Q>) -> i64;
+    fn entry(&mut self, timestamp: i64, order: &Order) -> i64;
 
     /// Returns the order response latency for the given timestamp and order.
-    fn response<Q: Clone>(&mut self, timestamp: i64, order: &Order<Q>) -> i64;
+    fn response(&mut self, timestamp: i64, order: &Order) -> i64;
 }
 
 /// Provides constant order latency.
@@ -44,11 +44,11 @@ impl ConstantLatency {
 }
 
 impl LatencyModel for ConstantLatency {
-    fn entry<Q: Clone>(&mut self, _timestamp: i64, _order: &Order<Q>) -> i64 {
+    fn entry(&mut self, _timestamp: i64, _order: &Order) -> i64 {
         self.entry_latency
     }
 
-    fn response<Q: Clone>(&mut self, _timestamp: i64, _order: &Order<Q>) -> i64 {
+    fn response(&mut self, _timestamp: i64, _order: &Order) -> i64 {
         self.response_latency
     }
 }
@@ -154,7 +154,7 @@ impl IntpOrderLatency {
 }
 
 impl LatencyModel for IntpOrderLatency {
-    fn entry<Q: Clone>(&mut self, timestamp: i64, _order: &Order<Q>) -> i64 {
+    fn entry(&mut self, timestamp: i64, _order: &Order) -> i64 {
         let first_row = &self.data[0];
         if timestamp < first_row.req_timestamp {
             return first_row.exch_timestamp - first_row.req_timestamp;
@@ -221,7 +221,7 @@ impl LatencyModel for IntpOrderLatency {
         }
     }
 
-    fn response<Q: Clone>(&mut self, timestamp: i64, _order: &Order<Q>) -> i64 {
+    fn response(&mut self, timestamp: i64, _order: &Order) -> i64 {
         let first_row = &self.data[0];
         if timestamp < first_row.exch_timestamp {
             return first_row.resp_timestamp - first_row.exch_timestamp;

--- a/rust/src/backtest/order.rs
+++ b/rust/src/backtest/order.rs
@@ -5,17 +5,11 @@ use crate::types::Order;
 /// Provides a bus for transporting backtesting orders between the exchange and the local model
 /// based on the given timestamp.
 #[derive(Clone, Debug)]
-pub struct OrderBus<Q>
-where
-    Q: Clone,
-{
-    order_list: Rc<UnsafeCell<VecDeque<(Order<Q>, i64)>>>,
+pub struct OrderBus {
+    order_list: Rc<UnsafeCell<VecDeque<(Order, i64)>>>,
 }
 
-impl<Q> OrderBus<Q>
-where
-    Q: Clone,
-{
+impl OrderBus {
     /// Constructs an instance of `OrderBus`.
     pub fn new() -> Self {
         Self {
@@ -39,7 +33,7 @@ where
     /// later to reach the matching engine before order requests sent earlier. However, for the
     /// purpose of simplifying the backtesting process, all requests and responses are assumed to be
     /// in order.
-    pub fn append(&mut self, order: Order<Q>, timestamp: i64) {
+    pub fn append(&mut self, order: Order, timestamp: i64) {
         let latest_timestamp = {
             let order_list = unsafe { &*self.order_list.get() };
             let len = order_list.len();
@@ -65,7 +59,7 @@ where
     }
 
     /// Removes the first order and its timestamp and returns it, or `None` if the bus is empty.
-    pub fn pop_front(&mut self) -> Option<(Order<Q>, i64)> {
+    pub fn pop_front(&mut self) -> Option<(Order, i64)> {
         unsafe { &mut *self.order_list.get() }.pop_front()
     }
 }

--- a/rust/src/backtest/proc/local.rs
+++ b/rust/src/backtest/proc/local.rs
@@ -37,19 +37,18 @@ use crate::{
 };
 
 /// The local model.
-pub struct Local<AT, Q, LM, MD>
+pub struct Local<AT, LM, MD>
 where
     AT: AssetType,
-    Q: Clone,
     LM: LatencyModel,
     MD: MarketDepth,
 {
     reader: Reader<Event>,
     data: Data<Event>,
     row_num: usize,
-    orders: HashMap<i64, Order<Q>>,
-    orders_to: OrderBus<Q>,
-    orders_from: OrderBus<Q>,
+    orders: HashMap<i64, Order>,
+    orders_to: OrderBus,
+    orders_from: OrderBus,
     depth: MD,
     state: State<AT>,
     order_latency: LM,
@@ -58,10 +57,9 @@ where
     last_order_latency: Option<(i64, i64, i64)>,
 }
 
-impl<AT, Q, LM, MD> Local<AT, Q, LM, MD>
+impl<AT, LM, MD> Local<AT, LM, MD>
 where
     AT: AssetType,
-    Q: Clone + Default,
     LM: LatencyModel,
     MD: MarketDepth,
 {
@@ -72,8 +70,8 @@ where
         state: State<AT>,
         order_latency: LM,
         trade_len: usize,
-        orders_to: OrderBus<Q>,
-        orders_from: OrderBus<Q>,
+        orders_to: OrderBus,
+        orders_from: OrderBus,
     ) -> Self {
         Self {
             reader,
@@ -91,7 +89,7 @@ where
         }
     }
 
-    fn process_recv_order_(&mut self, order: Order<Q>) -> Result<(), BacktestError> {
+    fn process_recv_order_(&mut self, order: Order) -> Result<(), BacktestError> {
         if order.status == Status::Filled {
             self.state.apply_fill(&order);
         }
@@ -108,10 +106,9 @@ where
     }
 }
 
-impl<AT, Q, LM, MD> LocalProcessor<Q, MD> for Local<AT, Q, LM, MD>
+impl<AT, LM, MD> LocalProcessor<MD> for Local<AT, LM, MD>
 where
     AT: AssetType,
-    Q: Clone + Default,
     LM: LatencyModel,
     MD: MarketDepth,
 {
@@ -212,7 +209,7 @@ where
         &self.depth
     }
 
-    fn orders(&self) -> &HashMap<i64, Order<Q>> {
+    fn orders(&self) -> &HashMap<i64, Order> {
         &self.orders
     }
 
@@ -233,10 +230,9 @@ where
     }
 }
 
-impl<AT, Q, LM, MD> Processor for Local<AT, Q, LM, MD>
+impl<AT, LM, MD> Processor for Local<AT, LM, MD>
 where
     AT: AssetType,
-    Q: Clone + Default,
     LM: LatencyModel,
     MD: MarketDepth,
 {

--- a/rust/src/backtest/proc/proc.rs
+++ b/rust/src/backtest/proc/proc.rs
@@ -7,9 +7,8 @@ use crate::{
 };
 
 /// Provides local-specific interaction.
-pub trait LocalProcessor<Q, MD>: Processor
+pub trait LocalProcessor<MD>: Processor
 where
-    Q: Clone,
     MD: MarketDepth,
 {
     /// Submits a new order.
@@ -54,7 +53,7 @@ where
     fn depth(&self) -> &MD;
 
     /// Returns a hash map of order IDs and their corresponding [`Order`]s.
-    fn orders(&self) -> &HashMap<i64, Order<Q>>;
+    fn orders(&self) -> &HashMap<i64, Order>;
 
     /// Returns the last market trades.
     fn trade(&self) -> &Vec<Event>;

--- a/rust/src/backtest/recorder.rs
+++ b/rust/src/backtest/recorder.rs
@@ -18,10 +18,9 @@ pub struct BacktestRecorder {
 impl Recorder for BacktestRecorder {
     type Error = Error;
 
-    fn record<Q, MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
+    fn record<MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
     where
-        Q: Sized + Clone,
-        I: Interface<Q, MD>,
+        I: Interface<MD>,
         MD: MarketDepth,
     {
         let timestamp = hbt.current_timestamp();
@@ -47,10 +46,9 @@ impl Recorder for BacktestRecorder {
 
 impl BacktestRecorder {
     /// Constructs an instance of `BacktestRecorder`.
-    pub fn new<Q, MD, I>(hbt: &I) -> Self
+    pub fn new<MD, I>(hbt: &I) -> Self
     where
-        Q: Sized + Clone,
-        I: Interface<Q, MD>,
+        I: Interface<MD>,
         MD: MarketDepth,
     {
         Self {

--- a/rust/src/backtest/state.rs
+++ b/rust/src/backtest/state.rs
@@ -34,7 +34,7 @@ where
         }
     }
 
-    pub fn apply_fill<Q: Clone + Default>(&mut self, order: &Order<Q>) {
+    pub fn apply_fill(&mut self, order: &Order) {
         let fee = if order.maker {
             self.maker_fee
         } else {

--- a/rust/src/connector/binancefutures/mod.rs
+++ b/rust/src/connector/binancefutures/mod.rs
@@ -371,7 +371,7 @@ impl Connector for BinanceFutures {
     fn submit(
         &self,
         asset_no: usize,
-        mut order: Order<()>,
+        mut order: Order,
         tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error> {
         let asset_info = self
@@ -448,7 +448,7 @@ impl Connector for BinanceFutures {
     fn cancel(
         &self,
         asset_no: usize,
-        mut order: Order<()>,
+        mut order: Order,
         tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error> {
         let asset_info = self

--- a/rust/src/connector/binancefutures/rest.rs
+++ b/rust/src/connector/binancefutures/rest.rs
@@ -372,7 +372,7 @@ impl BinanceFuturesClient {
     pub async fn get_current_all_open_orders(
         &self,
         assets: &HashMap<String, Asset>,
-    ) -> Result<Vec<Order<()>>, reqwest::Error> {
+    ) -> Result<Vec<Order>, reqwest::Error> {
         let resp: Vec<OrderResponse> = self
             .get(
                 "/fapi/v1/openOrders",
@@ -403,8 +403,7 @@ impl BinanceFuturesClient {
                             order_id,
                             order_type: data.ty,
                             // Invalid information
-                            front_q_qty: 0.0,
-                            q: (),
+                            q: Box::new(()),
                             maker: false,
                         },
                     )

--- a/rust/src/connector/binancefutures/ws.rs
+++ b/rust/src/connector/binancefutures/ws.rs
@@ -274,8 +274,7 @@ pub async fn connect(
                                             order_id,
                                             order_type: data.order.order_type,
                                             // Invalid information
-                                            front_q_qty: 0.0,
-                                            q: (),
+                                            q: Box::new(()),
                                             maker: false
                                         };
 

--- a/rust/src/connector/bybit/mod.rs
+++ b/rust/src/connector/bybit/mod.rs
@@ -300,7 +300,7 @@ impl Connector for Bybit {
     fn submit(
         &self,
         asset_no: usize,
-        order: Order<()>,
+        order: Order,
         tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error> {
         let asset_info = self
@@ -321,7 +321,7 @@ impl Connector for Bybit {
     fn cancel(
         &self,
         asset_no: usize,
-        order: Order<()>,
+        order: Order,
         tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error> {
         let asset_info = self

--- a/rust/src/connector/bybit/ordermanager.rs
+++ b/rust/src/connector/bybit/ordermanager.rs
@@ -40,7 +40,7 @@ pub(super) enum HandleError {
 
 pub struct OrderManager {
     prefix: String,
-    orders: HashMap<i64, (usize, Order<()>)>,
+    orders: HashMap<i64, (usize, Order)>,
 }
 
 impl OrderManager {
@@ -60,7 +60,7 @@ impl OrderManager {
             .map_err(|e| HandleError::InvalidOrderId(e))
     }
 
-    pub fn update_order(&mut self, data: &PrivateOrder) -> Result<(usize, Order<()>), HandleError> {
+    pub fn update_order(&mut self, data: &PrivateOrder) -> Result<(usize, Order), HandleError> {
         let order_id = self.parse_order_id(&data.order_link_id)?;
         let (asset_no, order) = self
             .orders
@@ -81,7 +81,7 @@ impl OrderManager {
     pub fn update_execution(
         &mut self,
         data: &FastExecution,
-    ) -> Result<(usize, Order<()>), HandleError> {
+    ) -> Result<(usize, Order), HandleError> {
         let order_id = self.parse_order_id(&data.order_link_id)?;
         let (asset_no, order) = self
             .orders
@@ -98,7 +98,7 @@ impl OrderManager {
         symbol: &str,
         category: &str,
         asset_no: usize,
-        order: Order<()>,
+        order: Order,
     ) -> Result<BybitOrder, HandleError> {
         let price_prec = get_precision(order.tick_size);
         let bybit_order = BybitOrder {
@@ -174,7 +174,7 @@ impl OrderManager {
     pub fn update_submit_fail(
         &mut self,
         order_link_id: &str,
-    ) -> Result<(usize, Order<()>), HandleError> {
+    ) -> Result<(usize, Order), HandleError> {
         let order_id = self.parse_order_id(order_link_id)?;
         let (asset_no, mut order) = self
             .orders
@@ -188,7 +188,7 @@ impl OrderManager {
     pub fn update_cancel_fail(
         &mut self,
         order_link_id: &str,
-    ) -> Result<(usize, Order<()>), HandleError> {
+    ) -> Result<(usize, Order), HandleError> {
         let order_id = self.parse_order_id(order_link_id)?;
         let (asset_no, mut order) = self
             .orders
@@ -199,8 +199,8 @@ impl OrderManager {
         Ok((asset_no, order))
     }
 
-    pub fn clear_orders(&mut self) -> Vec<(usize, Order<()>)> {
-        let mut values: Vec<(usize, Order<()>)> = Vec::new();
+    pub fn clear_orders(&mut self) -> Vec<(usize, Order)> {
+        let mut values: Vec<(usize, Order)> = Vec::new();
         values.extend(self.orders.drain().map(|(_, (asset_no, mut order))| {
             order.status = Status::Canceled;
             (asset_no, order)

--- a/rust/src/connector/mod.rs
+++ b/rust/src/connector/mod.rs
@@ -33,7 +33,7 @@ pub trait Connector {
     fn submit(
         &self,
         asset_no: usize,
-        order: Order<()>,
+        order: Order,
         ev_tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error>;
 
@@ -43,7 +43,7 @@ pub trait Connector {
     fn cancel(
         &self,
         asset_no: usize,
-        order: Order<()>,
+        order: Order,
         ev_tx: Sender<LiveEvent>,
     ) -> Result<(), anyhow::Error>;
 }

--- a/rust/src/live/recorder.rs
+++ b/rust/src/live/recorder.rs
@@ -16,10 +16,9 @@ pub struct LoggingRecorder {
 impl Recorder for LoggingRecorder {
     type Error = ();
 
-    fn record<Q, MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
+    fn record<MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
     where
-        Q: Sized + Clone,
-        I: Interface<Q, MD>,
+        I: Interface<MD>,
         MD: MarketDepth,
     {
         for asset_no in 0..hbt.num_assets() {


### PR DESCRIPTION
refactor(rust): remove the `Q` generic type dependency in `Order`, which is needed for additional queue estimation data, because it complicates backtesting across multiple exchanges that use different models. Instead, use `Box<dyn AnyClone>`` to store the additional data, eliminating the type dependency.