### PR TITLE
Add a config.toml to make builds work on M1 by fixing linker errors on MacOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Without this change, builds will otherwise fail on Apple M1 CPUs when trying to build the Python extensions.

https://github.com/inferiorhumanorgans/r2-c166/blob/752b61d36acd1ddbbcd0844505f94093773e4cc5/README.md#building-on-osx

```
...
            "__Py_NoneStruct", referenced from:
                pyo3_ffi::object::Py_None::hda8ba4bd0026440a in libpyo3-4148043010e22fb2.rlib[8](pyo3-4148043010e22fb2.pyo3.d6121509127cc09a-cgu.05.rcgu.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)

error: could not compile `py-hftbacktest` (lib) due to 1 previous error
```

`cargo build` succeeds with this change.