### PR TITLE
Add a set of initial FeeModels and propagate the FeeModel across hftbacktest

### DIFF
--- a/hftbacktest-derive/src/lib.rs
+++ b/hftbacktest-derive/src/lib.rs
@@ -118,6 +118,7 @@ struct BuildAssetInput {
     latency_model: Vec<EnumArgs>,
     queue_model: Vec<EnumArgs>,
     exchange_model: Vec<EnumArgs>,
+    fee_model: Vec<EnumArgs>,
 }
 
 impl Parse for BuildAssetInput {
@@ -133,6 +134,7 @@ impl Parse for BuildAssetInput {
             latency_model: Default::default(),
             queue_model: Default::default(),
             exchange_model: Default::default(),
+            fee_model: Default::default(),
         };
 
         let mut content;
@@ -165,6 +167,13 @@ impl Parse for BuildAssetInput {
             .into_iter()
             .collect();
 
+        input.parse::<syn::token::Comma>()?;
+        let _bracket_token = bracketed!(content in input);
+        parsed_input.fee_model = content
+            .parse_terminated(EnumArgs::parse, Token![,])?
+            .into_iter()
+            .collect();
+
         Ok(parsed_input)
     }
 }
@@ -181,55 +190,61 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
         for latency_model in input.latency_model.iter() {
             for queue_model in input.queue_model.iter() {
                 for exchange_model in input.exchange_model.iter() {
-                    let at_ident = &asset_type.name;
-                    let at_args = &asset_type.args;
+                    for fee_model in input.fee_model.iter() {
+                        let at_ident = &asset_type.name;
+                        let at_args = &asset_type.args;
 
-                    let lm_ident = &latency_model.name;
-                    let lm_args = &latency_model.args;
+                        let lm_ident = &latency_model.name;
+                        let lm_args = &latency_model.args;
 
-                    let qm_ident = &queue_model.name;
-                    let qm_args = &queue_model.args;
+                        let qm_ident = &queue_model.name;
+                        let qm_args = &queue_model.args;
 
-                    let em_ident = &exchange_model.name;
-                    let em_args = &exchange_model.args;
+                        let em_ident = &exchange_model.name;
+                        let em_args = &exchange_model.args;
 
-                    let prob_func_ident = Ident::new(&format!("{}Func", qm_ident), qm_ident.span());
+                        let fm_ident = &fee_model.name;
+                        let fm_args = &fee_model.args;
 
-                    let qm_construct = if qm_ident.to_string().contains("ProbQueueModel") {
-                        quote! {
-                            ProbQueueModel::<#prob_func_ident, #marketdepth>::new(#prob_func_ident::new(#(#qm_args.clone()),*));
-                        }
-                    } else {
-                        quote! {
-                            #qm_ident::new();
-                        }
-                    };
+                        let prob_func_ident =
+                            Ident::new(&format!("{}Func", qm_ident), qm_ident.span());
 
-                    let depth_construct = match marketdepth.to_string().as_str() {
-                        "HashMapMarketDepth" => {
+                        let qm_construct = if qm_ident.to_string().contains("ProbQueueModel") {
                             quote! {
-                                #marketdepth::new(#asset.tick_size, #asset.lot_size);
+                                ProbQueueModel::<#prob_func_ident, #marketdepth>::new(#prob_func_ident::new(#(#qm_args.clone()),*));
                             }
-                        }
-                        "ROIVectorMarketDepth" => {
+                        } else {
                             quote! {
-                                #marketdepth::new(
-                                    #asset.tick_size,
-                                    #asset.lot_size,
-                                    #asset.roi_lb,
-                                    #asset.roi_ub
-                                );
+                                #qm_ident::new();
                             }
-                        }
-                        _ => panic!(),
-                    };
+                        };
 
-                    arms.push(quote! {
+                        let depth_construct = match marketdepth.to_string().as_str() {
+                            "HashMapMarketDepth" => {
+                                quote! {
+                                    #marketdepth::new(#asset.tick_size, #asset.lot_size);
+                                }
+                            }
+                            "ROIVectorMarketDepth" => {
+                                quote! {
+                                    #marketdepth::new(
+                                        #asset.tick_size,
+                                        #asset.lot_size,
+                                        #asset.roi_lb,
+                                        #asset.roi_ub
+                                    );
+                                }
+                            }
+                            _ => panic!(),
+                        };
+
+                        arms.push(quote! {
                         (
                             AssetType::#at_ident { #(#at_args),* },
                             LatencyModel::#lm_ident { #(#lm_args),* },
                             QueueModel::#qm_ident { #(#qm_args),* },
                             ExchangeKind::#em_ident { #(#em_args),* },
+                            FeeModel::#fm_ident { #(#fm_args),* },
                         ) => {
                             let cache = Cache::new();
                             let mut reader = Reader::new(cache);
@@ -250,6 +265,7 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
 
                             let asset_type = #at_ident::new(#(#at_args.clone()),*);
                             let latency_model = #lm_ident::new(#(#lm_args.clone()),*);
+                            let fee_model = #fm_ident::new(#(#fm_args.clone()),*);
 
                             let mut market_depth = #depth_construct;
                             match #asset.initial_snapshot.as_ref() {
@@ -266,10 +282,7 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
                             let local: Box<dyn LocalProcessor<#marketdepth, Event>> = Box::new(Local::new(
                                 reader.clone(),
                                 market_depth,
-                                State::new(asset_type.clone(), TradingValueFeeModel {
-                                    maker_fee: #asset.maker_fee,
-                                    taker_fee: #asset.taker_fee,
-                                }),
+                                State::new(asset_type.clone(), fee_model.clone()),
                                 latency_model.clone(),
                                 #asset.last_trades_cap,
                                 ob_local_to_exch.clone(),
@@ -293,10 +306,7 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
                             let exch: Box<dyn Processor> = Box::new(#em_ident::new(
                                 reader,
                                 market_depth,
-                                State::new(asset_type, TradingValueFeeModel {
-                                    maker_fee: #asset.maker_fee,
-                                    taker_fee: #asset.taker_fee,
-                                }),
+                                State::new(asset_type, fee_model.clone()),
                                 latency_model,
                                 queue_model,
                                 ob_exch_to_local,
@@ -309,6 +319,7 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
                             }
                         },
                     });
+                    }
                 }
             }
         }
@@ -319,7 +330,8 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
             &#asset.asset_type,
             &#asset.latency_model,
             &#asset.queue_model,
-            &#asset.exch_kind
+            &#asset.exch_kind,
+            &#asset.fee_model,
         ) {
             #(#arms)*
         }

--- a/hftbacktest-derive/src/lib.rs
+++ b/hftbacktest-derive/src/lib.rs
@@ -266,7 +266,10 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
                             let local: Box<dyn LocalProcessor<#marketdepth, Event>> = Box::new(Local::new(
                                 reader.clone(),
                                 market_depth,
-                                State::new(asset_type.clone(), #asset.maker_fee, #asset.taker_fee),
+                                State::new(asset_type.clone(), TradingValueFeeModel {
+                                    maker_fee: #asset.maker_fee,
+                                    taker_fee: #asset.taker_fee,
+                                }),
                                 latency_model.clone(),
                                 #asset.last_trades_cap,
                                 ob_local_to_exch.clone(),
@@ -290,7 +293,10 @@ pub fn build_asset(input: TokenStream) -> TokenStream {
                             let exch: Box<dyn Processor> = Box::new(#em_ident::new(
                                 reader,
                                 market_depth,
-                                State::new(asset_type, #asset.maker_fee, #asset.taker_fee),
+                                State::new(asset_type, TradingValueFeeModel {
+                                    maker_fee: #asset.maker_fee,
+                                    taker_fee: #asset.taker_fee,
+                                }),
                                 latency_model,
                                 queue_model,
                                 ob_exch_to_local,

--- a/hftbacktest/src/backtest/feemodel.rs
+++ b/hftbacktest/src/backtest/feemodel.rs
@@ -1,0 +1,54 @@
+use crate::types::Order;
+
+pub struct FeeArgs<'a> {
+    pub order: &'a Order,
+    pub amount: f64,
+}
+
+pub trait FeeModel {
+    // Calculates the fee amount.
+    fn amount(&self, args: FeeArgs) -> f64;
+}
+
+// fee based on a percentage of the order value, with the rate
+// depending on whether the order is a maker or taker.
+pub struct TradingValueFeeModel {
+    pub maker_fee: f64,
+    pub taker_fee: f64,
+}
+impl FeeModel for TradingValueFeeModel {
+    fn amount(&self, args: FeeArgs) -> f64 {
+        if args.order.maker {
+            self.maker_fee * args.amount
+        } else {
+            self.taker_fee * args.amount
+        }
+    }
+}
+// fee per trading quantity
+pub struct TradingQtyFeeModel {
+    pub per_qty_fee: f64,
+}
+impl FeeModel for TradingQtyFeeModel {
+    fn amount(&self, args: FeeArgs) -> f64 {
+        self.per_qty_fee * args.order.qty
+    }
+}
+
+// fee per trade
+pub struct FlatPerTradeFeeModel {
+    pub flat_fee: f64,
+}
+impl FeeModel for FlatPerTradeFeeModel {
+    fn amount(&self, args: FeeArgs) -> f64 {
+        self.flat_fee
+    }
+}
+
+// different fees based on the direction.
+pub struct DirectionalFeeModel {}
+impl FeeModel for DirectionalFeeModel {
+    fn amount(&self, args: FeeArgs) -> f64 {
+        panic!("Not implemented");
+    }
+}

--- a/hftbacktest/src/backtest/mod.rs
+++ b/hftbacktest/src/backtest/mod.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, io::Error as IoError, marker::PhantomData};
 
 pub use data::DataSource;
 use data::{Cache, Reader};
-use feemodel::TradingValueFeeModel;
+use feemodel::{CommonFees, TradingValueFeeModel};
 use thiserror::Error;
 
 use crate::{
@@ -254,8 +254,10 @@ where
             State::new(
                 asset_type,
                 TradingValueFeeModel {
-                    maker_fee: self.maker_fee,
-                    taker_fee: self.taker_fee,
+                    common_fees: CommonFees {
+                        maker_fee: self.maker_fee,
+                        taker_fee: self.taker_fee,
+                    },
                 },
             ),
             order_latency,
@@ -284,8 +286,10 @@ where
                     State::new(
                         asset_type,
                         TradingValueFeeModel {
-                            maker_fee: self.maker_fee,
-                            taker_fee: self.taker_fee,
+                            common_fees: CommonFees {
+                                maker_fee: self.maker_fee,
+                                taker_fee: self.taker_fee,
+                            },
                         },
                     ),
                     order_latency,
@@ -306,8 +310,10 @@ where
                     State::new(
                         asset_type,
                         TradingValueFeeModel {
-                            maker_fee: self.maker_fee,
-                            taker_fee: self.taker_fee,
+                            common_fees: CommonFees {
+                                maker_fee: self.maker_fee,
+                                taker_fee: self.taker_fee,
+                            },
                         },
                     ),
                     order_latency,
@@ -392,12 +398,13 @@ where
     }
 }
 
-impl<LM, AT, QM, MD> Default for AssetBuilder<LM, AT, QM, MD>
+impl<LM, AT, QM, MD, FM> Default for AssetBuilder<LM, AT, QM, MD, FM>
 where
     AT: AssetType + Clone + 'static,
     MD: MarketDepth + L2MarketDepth + 'static,
     QM: QueueModel<MD> + 'static,
     LM: LatencyModel + Clone + 'static,
+    FM: FeeModel + Clone + 'static,
 {
     fn default() -> Self {
         Self::new()

--- a/hftbacktest/src/backtest/proc/l3_local.rs
+++ b/hftbacktest/src/backtest/proc/l3_local.rs
@@ -36,11 +36,12 @@ use crate::{
 };
 
 /// The Level3 Market-By-Order local model.
-pub struct L3Local<AT, LM, MD>
+pub struct L3Local<AT, LM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     MD: L3MarketDepth,
+    FM: FeeModel,
 {
     reader: Reader<Event>,
     data: Data<Event>,
@@ -49,24 +50,25 @@ where
     orders_to: OrderBus,
     orders_from: OrderBus,
     depth: MD,
-    state: State<AT>,
+    state: State<AT, FM>,
     order_latency: LM,
     trades: Vec<Event>,
     last_feed_latency: Option<(i64, i64)>,
     last_order_latency: Option<(i64, i64, i64)>,
 }
 
-impl<AT, LM, MD> L3Local<AT, LM, MD>
+impl<AT, LM, MD> L3Local<AT, LM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     MD: L3MarketDepth,
+    FM: FeeModel,
 {
     /// Constructs an instance of `L3Local`.
     pub fn new(
         reader: Reader<Event>,
         depth: MD,
-        state: State<AT>,
+        state: State<AT, FM>,
         order_latency: LM,
         trade_len: usize,
         orders_to: OrderBus,

--- a/hftbacktest/src/backtest/proc/l3_nopartialfillexchange.rs
+++ b/hftbacktest/src/backtest/proc/l3_nopartialfillexchange.rs
@@ -55,11 +55,12 @@ use crate::{
 /// best. Be aware that this may cause unrealistic fill simulations if you attempt to execute a
 /// large quantity.
 ///
-pub struct L3NoPartialFillExchange<AT, LM, MD>
+pub struct L3NoPartialFillExchange<AT, LM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     MD: L3MarketDepth,
+    FM: FeeModel,
 {
     reader: Reader<Event>,
     data: Data<Event>,
@@ -68,23 +69,24 @@ where
     orders_from: OrderBus,
 
     depth: MD,
-    state: State<AT>,
+    state: State<AT, FM>,
     order_latency: LM,
     queue_model: L3FIFOQueueModel,
 }
 
-impl<AT, LM, MD> L3NoPartialFillExchange<AT, LM, MD>
+impl<AT, LM, MD> L3NoPartialFillExchange<AT, LM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     MD: L3MarketDepth,
+    FM: FeeModel,
     BacktestError: From<<MD as L3MarketDepth>::Error>,
 {
     /// Constructs an instance of `NoPartialFillExchange`.
     pub fn new(
         reader: Reader<Event>,
         depth: MD,
-        state: State<AT>,
+        state: State<AT, FM>,
         order_latency: LM,
         orders_to: OrderBus,
         orders_from: OrderBus,

--- a/hftbacktest/src/backtest/proc/nopartialfillexchange.rs
+++ b/hftbacktest/src/backtest/proc/nopartialfillexchange.rs
@@ -10,6 +10,7 @@ use crate::{
     backtest::{
         assettype::AssetType,
         data::{Data, Reader},
+        feemodel::FeeModel,
         models::{LatencyModel, QueueModel},
         order::OrderBus,
         proc::Processor,
@@ -62,12 +63,13 @@ use crate::{
 /// best. Be aware that this may cause unrealistic fill simulations if you attempt to execute a
 /// large quantity.
 ///
-pub struct NoPartialFillExchange<AT, LM, QM, MD>
+pub struct NoPartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth,
+    FM: FeeModel,
 {
     reader: Reader<Event>,
     data: Data<Event>,
@@ -83,25 +85,26 @@ where
     orders_from: OrderBus,
 
     depth: MD,
-    state: State<AT>,
+    state: State<AT, FM>,
     order_latency: LM,
     queue_model: QM,
 
     filled_orders: Vec<OrderId>,
 }
 
-impl<AT, LM, QM, MD> NoPartialFillExchange<AT, LM, QM, MD>
+impl<AT, LM, QM, MD, FM> NoPartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth,
+    FM: FeeModel,
 {
     /// Constructs an instance of `NoPartialFillExchange`.
     pub fn new(
         reader: Reader<Event>,
         depth: MD,
-        state: State<AT>,
+        state: State<AT, FM>,
         order_latency: LM,
         queue_model: QM,
         orders_to: OrderBus,
@@ -593,12 +596,13 @@ where
     }
 }
 
-impl<AT, LM, QM, MD> Processor for NoPartialFillExchange<AT, LM, QM, MD>
+impl<AT, LM, QM, MD, FM> Processor for NoPartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth + L2MarketDepth,
+    FM: FeeModel,
 {
     fn initialize_data(&mut self) -> Result<i64, BacktestError> {
         self.data = self.reader.next_data()?;

--- a/hftbacktest/src/backtest/proc/partialfillexchange.rs
+++ b/hftbacktest/src/backtest/proc/partialfillexchange.rs
@@ -10,6 +10,7 @@ use crate::{
     backtest::{
         assettype::AssetType,
         data::{Data, Reader},
+        feemodel::FeeModel,
         models::{LatencyModel, QueueModel},
         order::OrderBus,
         proc::Processor,
@@ -76,12 +77,13 @@ use crate::{
 /// results.
 /// (more comment will be added...)
 ///
-pub struct PartialFillExchange<AT, LM, QM, MD>
+pub struct PartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth,
+    FM: FeeModel,
 {
     reader: Reader<Event>,
     data: Data<Event>,
@@ -97,25 +99,26 @@ where
     orders_from: OrderBus,
 
     depth: MD,
-    state: State<AT>,
+    state: State<AT, FM>,
     order_latency: LM,
     queue_model: QM,
 
     filled_orders: Vec<OrderId>,
 }
 
-impl<AT, LM, QM, MD> PartialFillExchange<AT, LM, QM, MD>
+impl<AT, LM, QM, MD, FM> PartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth,
+    FM: FeeModel,
 {
     /// Constructs an instance of `PartialFillExchange`.
     pub fn new(
         reader: Reader<Event>,
         depth: MD,
-        state: State<AT>,
+        state: State<AT, FM>,
         order_latency: LM,
         queue_model: QM,
         orders_to: OrderBus,
@@ -777,12 +780,13 @@ where
     }
 }
 
-impl<AT, LM, QM, MD> Processor for PartialFillExchange<AT, LM, QM, MD>
+impl<AT, LM, QM, MD, FM> Processor for PartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
     QM: QueueModel<MD>,
     MD: MarketDepth + L2MarketDepth,
+    FM: FeeModel,
 {
     fn initialize_data(&mut self) -> Result<i64, BacktestError> {
         self.data = self.reader.next_data()?;

--- a/hftbacktest/src/backtest/state.rs
+++ b/hftbacktest/src/backtest/state.rs
@@ -1,24 +1,28 @@
 use crate::{
-    backtest::assettype::AssetType,
+    backtest::{
+        assettype::AssetType,
+        feemodel::{FeeArgs, FeeModel},
+    },
     types::{Order, StateValues},
 };
 
 #[derive(Debug)]
-pub struct State<AT>
+pub struct State<AT, FM>
 where
     AT: AssetType,
+    FM: FeeModel,
 {
     pub state_values: StateValues,
-    pub maker_fee: f64,
-    pub taker_fee: f64,
     pub asset_type: AT,
+    pub fee_model: FM,
 }
 
-impl<AT> State<AT>
+impl<AT, FM> State<AT, FM>
 where
     AT: AssetType,
+    FM: FeeModel,
 {
-    pub fn new(asset_type: AT, maker_fee: f64, taker_fee: f64) -> Self {
+    pub fn new(asset_type: AT, fee_model: FM) -> Self {
         Self {
             state_values: StateValues {
                 position: 0.0,
@@ -28,26 +32,23 @@ where
                 trading_volume: 0.0,
                 trading_value: 0.0,
             },
-            maker_fee,
-            taker_fee,
+            fee_model,
             asset_type,
         }
     }
 
     #[inline]
     pub fn apply_fill(&mut self, order: &Order) {
-        let fee = if order.maker {
-            self.maker_fee
-        } else {
-            self.taker_fee
-        };
         let amount = self.asset_type.amount(order.exec_price(), order.exec_qty);
         self.state_values.position += order.exec_qty * AsRef::<f64>::as_ref(&order.side);
         self.state_values.balance -= amount * AsRef::<f64>::as_ref(&order.side);
-        self.state_values.fee += amount * fee;
         self.state_values.num_trades += 1;
         self.state_values.trading_volume += order.exec_qty;
         self.state_values.trading_value += amount;
+        self.state_values.fee += self.fee_model.amount(FeeArgs {
+            order: order,
+            amount: amount,
+        });
     }
 
     #[inline]

--- a/hftbacktest/src/backtest/state.rs
+++ b/hftbacktest/src/backtest/state.rs
@@ -1,8 +1,5 @@
 use crate::{
-    backtest::{
-        assettype::AssetType,
-        feemodel::{FeeArgs, FeeModel},
-    },
+    backtest::{assettype::AssetType, feemodel::FeeModel},
     types::{Order, StateValues},
 };
 
@@ -45,10 +42,7 @@ where
         self.state_values.num_trades += 1;
         self.state_values.trading_volume += order.exec_qty;
         self.state_values.trading_value += amount;
-        self.state_values.fee += self.fee_model.amount(FeeArgs {
-            order: order,
-            amount: amount,
-        });
+        self.state_values.fee += self.fee_model.amount(order, amount);
     }
 
     #[inline]

--- a/py-hftbacktest/src/lib.rs
+++ b/py-hftbacktest/src/lib.rs
@@ -6,6 +6,7 @@ use hftbacktest::{
     backtest::{
         assettype::{InverseAsset, LinearAsset},
         data::{read_npz_file, Cache, Data, DataPtr, Reader},
+        feemodel::TradingValueFeeModel,
         models::{
             ConstantLatency,
             IntpOrderLatency,


### PR DESCRIPTION
Add a set of initial FeeModels and propagate the FeeModel across hftbacktest. These FeeModels could probably use some refinement, but this PR should mostly act as a no-op to use the percentage-based fee.