### PR TITLE
Implemented function to create snapshot up to orderbook level L

### DIFF
--- a/hftbacktest/src/depth/btreemarketdepth.rs
+++ b/hftbacktest/src/depth/btreemarketdepth.rs
@@ -191,6 +191,25 @@ impl MarketDepth for BTreeMarketDepth {
     fn ask_qty_at_tick(&self, price_tick: i64) -> f64 {
         *self.ask_depth.get(&price_tick).unwrap_or(&0.0)
     }
+
+    #[inline(always)]
+    fn bid_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        self.bid_depth.iter()
+            .rev()
+            .take(level)
+            .map(|(&price_tick, &qty)| (price_tick as f64 * self.tick_size, qty))
+            .collect::<Vec<(f64, f64)>>()
+    }
+    
+    #[inline(always)]
+    fn ask_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        self.ask_depth.iter()
+            .take(level)
+            .map(|(&price_tick, &qty)| (price_tick as f64 * self.tick_size, qty))
+            .collect::<Vec<(f64, f64)>>()
+    }
+    
+    
 }
 
 impl ApplySnapshot for BTreeMarketDepth {

--- a/hftbacktest/src/depth/fuse.rs
+++ b/hftbacktest/src/depth/fuse.rs
@@ -338,6 +338,8 @@ impl MarketDepth for FusedHashMapMarketDepth {
             .unwrap_or(&Default::default())
             .qty
     }
+
+    
 }
 
 impl ApplySnapshot for FusedHashMapMarketDepth {

--- a/hftbacktest/src/depth/hashmapmarketdepth.rs
+++ b/hftbacktest/src/depth/hashmapmarketdepth.rs
@@ -278,6 +278,37 @@ impl MarketDepth for HashMapMarketDepth {
     fn ask_qty_at_tick(&self, price_tick: i64) -> f64 {
         *self.ask_depth.get(&price_tick).unwrap_or(&0.0)
     }
+    
+    #[inline(always)]
+    fn bid_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        let mut bid_depth = self
+            .bid_depth
+            .iter()
+            .map(|(&price_tick, &qty)| (price_tick, qty))
+            .collect::<Vec<_>>();
+        bid_depth.sort_by(|a, b| b.0.cmp(&a.0));
+        bid_depth
+            .into_iter()
+            .take(level)
+            .map(|(price_tick, qty)| (price_tick as f64 * self.tick_size, qty))
+            .collect::<Vec<(f64, f64)>>()
+    }
+    
+    #[inline(always)]
+    fn ask_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        let mut ask_depth = self
+            .ask_depth
+            .iter()
+            .map(|(&price_tick, &qty)| (price_tick, qty))
+            .collect::<Vec<_>>();
+        ask_depth.sort_by(|a, b| a.0.cmp(&b.0));
+        ask_depth
+            .into_iter()
+            .take(level)
+            .map(|(price_tick, qty)| (price_tick as f64 * self.tick_size, qty))
+            .collect::<Vec<(f64, f64)>>()
+    }
+    
 }
 
 impl ApplySnapshot for HashMapMarketDepth {

--- a/hftbacktest/src/depth/mod.rs
+++ b/hftbacktest/src/depth/mod.rs
@@ -56,6 +56,12 @@ pub trait MarketDepth {
 
     /// Returns the quantity at the ask market depth for a given price in ticks.
     fn ask_qty_at_tick(&self, price_tick: i64) -> f64;
+
+    /// Returns the bid depth at a specific level.
+    fn bid_depth_level(&self, level: usize) -> Vec<(f64, f64)>;
+
+    /// Returns the ask depth at a specific level.
+    fn ask_depth_level(&self, level: usize) -> Vec<(f64, f64)>;
 }
 
 /// Provides Level2-specific market depth functions.

--- a/hftbacktest/src/depth/roivectormarketdepth.rs
+++ b/hftbacktest/src/depth/roivectormarketdepth.rs
@@ -366,6 +366,17 @@ impl MarketDepth for ROIVectorMarketDepth {
             }
         }
     }
+
+    #[inline(always)] 
+    fn bid_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        unimplemented!()
+    }
+    
+    #[inline(always)] 
+    fn ask_depth_level(&self, level: usize) -> Vec<(f64, f64)> {
+        unimplemented!()
+    }
+    
 }
 
 impl ApplySnapshot for ROIVectorMarketDepth {


### PR DESCRIPTION
## Overview
Currently, the MD (MarketDepth) trait only allows retrieval of the best bid/ask tick and quantity.

## Improvements
I have written a function to create a snapshot up to Level L in the format Vec<(f64, f64)>.

## Example
```bash
/// bids depth 
[(500.1, 0.006), (500.0, 0.002)]
```

