### PR TITLE
Introduce benchmarks for npy/npz readers

### DIFF
--- a/hftbacktest/Cargo.toml
+++ b/hftbacktest/Cargo.toml
@@ -54,6 +54,11 @@ hftbacktest-derive = { path = "../hftbacktest-derive", optional = true, version 
 [dev-dependencies]
 tracing-subscriber = { version = "0.3.18", features = [] }
 clap = { version = "4.5.4", features = ["derive"] }
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "formats"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/hftbacktest/benches/formats.rs
+++ b/hftbacktest/benches/formats.rs
@@ -1,0 +1,62 @@
+use criterion::*;
+use hftbacktest::backtest::data::{read_npy_file, write_npy, write_npz};
+use hftbacktest::{
+    backtest::data::{read_npz_file, Data},
+    types::Event,
+};
+use std::fs::File;
+use std::time::Duration;
+use std::{fs, ops::Index};
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("format-throughput");
+    let events: Vec<Event> = (0..1000_000)
+        .map(|id| Event {
+            ev: id,
+            exch_ts: 1_000_000,
+            local_ts: 1_000_001,
+            px: 1.0,
+            qty: 1.0,
+            order_id: 1,
+            ival: 100,
+            fval: 100.0,
+        })
+        .collect();
+
+    let mut npy_file = File::create("bench.npy").expect("couldn't create bench.npy");
+    let mut npz_file = File::create("bench.npz").expect("couldn't create bench.npz");
+
+    write_npy(&mut npy_file, &events).expect("failed to generate npy file");
+    write_npz(&mut npz_file, &events).expect("failed to generate npz file");
+
+    group.throughput(Throughput::Elements(events.len() as u64));
+    group.warm_up_time(Duration::from_secs(10));
+    group.bench_function("npz", |b| {
+        b.iter(|| benchmark_npz_file())
+    });
+    group.bench_function("npy", |b| b.iter(|| benchmark_npy_file()));
+    group.finish();
+
+    let _ = fs::remove_file("bench.npy");
+    let _ = fs::remove_file("bench.npz");
+}
+
+#[inline]
+fn read_all(data: Data<Event>) {
+    for index in 0..data.len() {
+        black_box(data.index(index));
+    }
+}
+
+fn benchmark_npz_file() {
+    let data = read_npz_file::<Event>("bench.npz", "data").unwrap();
+    read_all(data);
+}
+
+fn benchmark_npy_file() {
+    let data = read_npy_file::<Event>("bench.npy").unwrap();
+    read_all(data);
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/hftbacktest/src/backtest/data/mod.rs
+++ b/hftbacktest/src/backtest/data/mod.rs
@@ -10,7 +10,7 @@ use std::{
     slice::SliceIndex,
 };
 
-pub use npy::{read_npy_file, read_npz_file, write_npy, Field, NpyDTyped, NpyHeader};
+pub use npy::{read_npy_file, read_npz_file, write_npy, write_npz, Field, NpyDTyped, NpyHeader};
 pub use reader::{Cache, DataSource, Reader};
 
 use crate::utils::{AlignedArray, CACHE_LINE_SIZE};


### PR DESCRIPTION
This is a WIP and just some groundwork to get some figures on the recent conversations around improving backtest performance.

`cargo bench` will produce a report on the command-line with a comparison against the previous run if available:

```
format-throughput/npz   time:   [40.665 ms 40.878 ms 41.108 ms]
                        thrpt:  [24.326 Melem/s 24.463 Melem/s 24.591 Melem/s]
                 change:
                        time:   [+0.1910% +1.0585% +1.8781%] (p = 0.02 < 0.05)
                        thrpt:  [-1.8434% -1.0475% -0.1906%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
format-throughput/npy   time:   [28.188 ms 28.509 ms 28.846 ms]
                        thrpt:  [34.667 Melem/s 35.077 Melem/s 35.476 Melem/s]
                 change:
                        time:   [-2.0433% -0.3669% +1.4170%] (p = 0.68 > 0.05)
                        thrpt:  [-1.3972% +0.3682% +2.0859%]
                        No change in performance detected.

````