### PR TITLE
Read event data in parallel to backtest

### DIFF
--- a/hftbacktest/Cargo.toml
+++ b/hftbacktest/Cargo.toml
@@ -49,6 +49,7 @@ hmac = { version = "0.13.0-pre.3", optional = true }
 rand = { version = "0.8.5", optional = true }
 uuid = { version = "1.8.0", features = ["v4"], optional = true }
 nom = { version = "7.1.3", optional = true }
+bus = { version = "2.4" }
 hftbacktest-derive = { path = "../hftbacktest-derive", optional = true, version = "0.1.0" }
 
 [dev-dependencies]

--- a/hftbacktest/src/backtest/data/bus.rs
+++ b/hftbacktest/src/backtest/data/bus.rs
@@ -1,0 +1,106 @@
+use std::{io, io::ErrorKind};
+use std::iter::Peekable;
+use bus::{Bus, BusIntoIter, BusReader};
+use tracing::{error, info, info_span};
+
+use crate::backtest::{
+    data::{read_npy_file, read_npz_file, Data, NpyDTyped},
+    BacktestError,
+};
+
+#[derive(Copy, Clone)]
+pub enum EventBusMessage<EventT: Clone> {
+    Item(EventT),
+    EndOfData,
+}
+
+pub struct EventBusReader<EventT: Clone + Send + Sync> {
+    reader: Peekable<BusIntoIter<EventBusMessage<EventT>>>,
+}
+
+impl<EventT: Clone + Send + Sync> EventBusReader<EventT> {
+    pub fn new(reader: BusReader<EventBusMessage<EventT>>) -> Self {
+        Self {
+            reader: reader.into_iter().peekable()
+        }
+    }
+
+    pub fn peek(&mut self) -> Option<&EventT> {
+        self.reader.peek().and_then(|ev| match ev {
+            EventBusMessage::Item(item) => Some(item),
+            EventBusMessage::EndOfData => None,
+        })
+    }
+
+    pub fn next(&mut self) -> Option<EventT> {
+        self.reader.next().and_then(|ev| match ev {
+            EventBusMessage::Item(item) => Some(item),
+            EventBusMessage::EndOfData => None,
+        })
+    }
+}
+
+pub trait TimestampedEventQueue<EventT> {
+    fn next_event(&mut self) -> Option<EventT>;
+
+    fn peek_event(&mut self) -> Option<&EventT>;
+
+    fn event_time(value: &EventT) -> i64;
+}
+
+pub trait EventConsumer<EventT> {
+    fn is_event_relevant(event: &EventT) -> bool;
+
+    fn process_event(&mut self, event: EventT) -> Result<(), BacktestError>;
+}
+
+fn load_data<EventT: NpyDTyped + Clone + Send>(
+    filepath: String,
+) -> Result<Data<EventT>, BacktestError> {
+    let data = if filepath.ends_with(".npy") {
+        read_npy_file(&filepath)?
+    } else if filepath.ends_with(".npz") {
+        read_npz_file(&filepath, "data")?
+    } else {
+        return Err(BacktestError::DataError(io::Error::new(
+            ErrorKind::InvalidData,
+            "unsupported data type",
+        )));
+    };
+
+    Ok(data)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn replay_events_to_bus<EventT: NpyDTyped + Clone + Send + 'static>(
+    mut bus: Bus<EventBusMessage<EventT>>,
+    mut sources: Vec<String>,
+) {
+    for source in sources.drain(..) {
+        let source_load_span = info_span!("load_data", source = &source);
+        let _source_load_span = source_load_span.entered();
+
+        let data = load_data::<EventT>(source);
+
+        match data {
+            Ok(data) => {
+                info!(
+                    records = data.len(),
+                    "found {} events in data source",
+                    data.len()
+                );
+
+                for row in 0..data.len() {
+                    bus.broadcast(EventBusMessage::Item(data[row].clone()));
+                }
+            }
+            Err(e) => {
+                error!("encountered error loading data source: {}", e);
+                // TODO: handle as an error.
+                break;
+            }
+        }
+    }
+
+    bus.broadcast(EventBusMessage::EndOfData);
+}

--- a/hftbacktest/src/backtest/data/mod.rs
+++ b/hftbacktest/src/backtest/data/mod.rs
@@ -1,3 +1,4 @@
+mod bus;
 mod npy;
 mod reader;
 
@@ -10,6 +11,7 @@ use std::{
     slice::SliceIndex,
 };
 
+pub use bus::{replay_events_to_bus, EventBusMessage, EventBusReader, EventConsumer, TimestampedEventQueue};
 pub use npy::{read_npy_file, read_npz_file, write_npy, Field, NpyDTyped, NpyHeader};
 pub use reader::{Cache, DataSource, Reader};
 
@@ -106,6 +108,8 @@ where
         unsafe { &*(self.ptr.at(i) as *const D) }
     }
 }
+
+unsafe impl Send for DataPtr {}
 
 #[derive(Debug)]
 pub struct DataPtr {

--- a/hftbacktest/src/backtest/data/reader.rs
+++ b/hftbacktest/src/backtest/data/reader.rs
@@ -3,6 +3,7 @@ use std::{
     collections::HashMap,
     io::{Error as IoError, ErrorKind},
     rc::Rc,
+    sync::Arc,
 };
 
 use uuid::Uuid;
@@ -60,7 +61,7 @@ where
 /// Provides a data cache that allows both the local processor and exchange processor to access the
 /// same or different data based on their timestamps without the need for reloading.
 #[derive(Clone, Debug)]
-pub struct Cache<D>(Rc<RefCell<HashMap<String, CachedData<D>>>>)
+pub struct Cache<D>(Arc<RefCell<HashMap<String, CachedData<D>>>>)
 where
     D: POD + Clone;
 

--- a/hftbacktest/src/backtest/proc/l3_local.rs
+++ b/hftbacktest/src/backtest/proc/l3_local.rs
@@ -9,7 +9,7 @@ use crate::{
         data::{Data, Reader},
         models::{FeeModel, LatencyModel},
         order::OrderBus,
-        proc::{LocalProcessor, Processor},
+        proc::{LocalProcessor, OrderConsumer, Processor},
         state::State,
         BacktestError,
     },
@@ -312,7 +312,16 @@ where
 
         Ok((next_ts, i64::MAX))
     }
+}
 
+impl<AT, LM, MD, FM> OrderConsumer for L3Local<AT, LM, MD, FM>
+where
+    AT: AssetType,
+    LM: LatencyModel,
+    MD: L3MarketDepth,
+    FM: FeeModel,
+    BacktestError: From<<MD as L3MarketDepth>::Error>,
+{
     fn process_recv_order(
         &mut self,
         timestamp: i64,
@@ -347,11 +356,9 @@ where
         }
         Ok(wait_resp_order_received)
     }
-
     fn earliest_recv_order_timestamp(&self) -> i64 {
         self.orders_from.earliest_timestamp().unwrap_or(i64::MAX)
     }
-
     fn earliest_send_order_timestamp(&self) -> i64 {
         self.orders_to.earliest_timestamp().unwrap_or(i64::MAX)
     }

--- a/hftbacktest/src/backtest/proc/l3_nopartialfillexchange.rs
+++ b/hftbacktest/src/backtest/proc/l3_nopartialfillexchange.rs
@@ -1,12 +1,14 @@
 use std::mem;
 
+use bus::BusReader;
+
 use crate::{
     backtest::{
         assettype::AssetType,
-        data::{Data, Reader},
+        data::{Data, EventConsumer, Reader},
         models::{FeeModel, L3QueueModel, LatencyModel},
         order::OrderBus,
-        proc::Processor,
+        proc::{OrderConsumer, Processor},
         state::State,
         BacktestError,
     },
@@ -63,8 +65,7 @@ where
     MD: L3MarketDepth,
     FM: FeeModel,
 {
-    reader: Reader<Event>,
-    data: Data<Event>,
+    reader: BusReader<Event>,
     row_num: usize,
     orders_to: OrderBus,
     orders_from: OrderBus,
@@ -86,7 +87,7 @@ where
 {
     /// Constructs an instance of `NoPartialFillExchange`.
     pub fn new(
-        reader: Reader<Event>,
+        reader: BusReader<Event>,
         depth: MD,
         state: State<AT, FM>,
         queue_model: QM,
@@ -96,7 +97,6 @@ where
     ) -> Self {
         Self {
             reader,
-            data: Data::empty(),
             row_num: 0,
             orders_to,
             orders_from,
@@ -300,7 +300,7 @@ where
     }
 }
 
-impl<AT, LM, QM, MD, FM> Processor for L3NoPartialFillExchange<AT, LM, QM, MD, FM>
+impl<AT, LM, QM, MD, FM> EventConsumer<Event> for L3NoPartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
@@ -309,134 +309,88 @@ where
     FM: FeeModel,
     BacktestError: From<<MD as L3MarketDepth>::Error>,
 {
-    fn initialize_data(&mut self) -> Result<i64, BacktestError> {
-        self.data = self.reader.next_data()?;
-        for rn in 0..self.data.len() {
-            if self.data[rn].is(EXCH_EVENT) {
-                self.row_num = rn;
-                return Ok(self.data[rn].exch_ts);
-            }
-        }
-        Err(BacktestError::EndOfData)
+    fn is_event_relevant(&self, event: &EventT) -> bool {
+        event.is(EXCH_EVENT)
     }
 
-    fn process_data(&mut self) -> Result<(i64, i64), BacktestError> {
-        let row_num = self.row_num;
-        if self.data[row_num].is(EXCH_BID_DEPTH_CLEAR_EVENT) {
+    fn process_event(&mut self, event: Event) -> Result<(), BacktestError> {
+        if event.is(EXCH_BID_DEPTH_CLEAR_EVENT) {
             self.depth.clear_orders(Side::Buy);
             let expired = self.queue_model.clear_orders(Side::Buy);
             for order in expired {
-                self.expired(order, self.data[row_num].exch_ts)?;
+                self.expired(order, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_ASK_DEPTH_CLEAR_EVENT) {
+        } else if event.is(EXCH_ASK_DEPTH_CLEAR_EVENT) {
             self.depth.clear_orders(Side::Sell);
             let expired = self.queue_model.clear_orders(Side::Sell);
             for order in expired {
-                self.expired(order, self.data[row_num].exch_ts)?;
+                self.expired(order, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_DEPTH_CLEAR_EVENT) {
+        } else if event.is(EXCH_DEPTH_CLEAR_EVENT) {
             self.depth.clear_orders(Side::None);
             let expired = self.queue_model.clear_orders(Side::None);
             for order in expired {
-                self.expired(order, self.data[row_num].exch_ts)?;
+                self.expired(order, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_BID_ADD_ORDER_EVENT) {
-            let (prev_best_bid_tick, best_bid_tick) = self.depth.add_buy_order(
-                self.data[row_num].order_id,
-                self.data[row_num].px,
-                self.data[row_num].qty,
-                self.data[row_num].exch_ts,
-            )?;
+        } else if event.is(EXCH_BID_ADD_ORDER_EVENT) {
+            let (prev_best_bid_tick, best_bid_tick) =
+                self.depth
+                    .add_buy_order(event.order_id, event.px, event.qty, event.exch_ts)?;
             self.queue_model
-                .add_market_feed_order(&self.data[row_num], &self.depth)?;
+                .add_market_feed_order(&event, &self.depth)?;
             if best_bid_tick > prev_best_bid_tick {
-                self.fill_ask_orders_by_crossing(
-                    prev_best_bid_tick,
-                    best_bid_tick,
-                    self.data[row_num].exch_ts,
-                )?;
+                self.fill_ask_orders_by_crossing(prev_best_bid_tick, best_bid_tick, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_ASK_ADD_ORDER_EVENT) {
-            let (prev_best_ask_tick, best_ask_tick) = self.depth.add_sell_order(
-                self.data[row_num].order_id,
-                self.data[row_num].px,
-                self.data[row_num].qty,
-                self.data[row_num].exch_ts,
-            )?;
+        } else if event.is(EXCH_ASK_ADD_ORDER_EVENT) {
+            let (prev_best_ask_tick, best_ask_tick) =
+                self.depth
+                    .add_sell_order(event.order_id, event.px, event.qty, event.exch_ts)?;
             self.queue_model
-                .add_market_feed_order(&self.data[row_num], &self.depth)?;
+                .add_market_feed_order(&event, &self.depth)?;
             if best_ask_tick < prev_best_ask_tick {
-                self.fill_bid_orders_by_crossing(
-                    prev_best_ask_tick,
-                    best_ask_tick,
-                    self.data[row_num].exch_ts,
-                )?;
+                self.fill_bid_orders_by_crossing(prev_best_ask_tick, best_ask_tick, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_MODIFY_ORDER_EVENT) {
-            let (side, prev_best_tick, best_tick) = self.depth.modify_order(
-                self.data[row_num].order_id,
-                self.data[row_num].px,
-                self.data[row_num].qty,
-                self.data[row_num].exch_ts,
-            )?;
-            self.queue_model.modify_market_feed_order(
-                self.data[row_num].order_id,
-                &self.data[row_num],
-                &self.depth,
-            )?;
+        } else if event.is(EXCH_MODIFY_ORDER_EVENT) {
+            let (side, prev_best_tick, best_tick) =
+                self.depth
+                    .modify_order(event.order_id, event.px, event.qty, event.exch_ts)?;
+            self.queue_model
+                .modify_market_feed_order(event.order_id, &event, &self.depth)?;
             if side == Side::Buy {
                 if best_tick > prev_best_tick {
-                    self.fill_ask_orders_by_crossing(
-                        prev_best_tick,
-                        best_tick,
-                        self.data[row_num].exch_ts,
-                    )?;
+                    self.fill_ask_orders_by_crossing(prev_best_tick, best_tick, event.exch_ts)?;
                 }
             } else if best_tick < prev_best_tick {
-                self.fill_bid_orders_by_crossing(
-                    prev_best_tick,
-                    best_tick,
-                    self.data[row_num].exch_ts,
-                )?;
+                self.fill_bid_orders_by_crossing(prev_best_tick, best_tick, event.exch_ts)?;
             }
-        } else if self.data[row_num].is(EXCH_CANCEL_ORDER_EVENT) {
-            let _ = self
-                .depth
-                .delete_order(self.data[row_num].order_id, self.data[row_num].exch_ts)?;
+        } else if event.is(EXCH_CANCEL_ORDER_EVENT) {
+            let _ = self.depth.delete_order(event.order_id, event.exch_ts)?;
             self.queue_model
-                .cancel_market_feed_order(self.data[row_num].order_id, &self.depth)?;
-        } else if self.data[row_num].is(EXCH_FILL_EVENT) {
+                .cancel_market_feed_order(event.order_id, &self.depth)?;
+        } else if event.is(EXCH_FILL_EVENT) {
             let filled = self
                 .queue_model
-                .fill_market_feed_order::<false>(self.data[row_num].order_id, &self.depth)?;
-            let timestamp = self.data[row_num].exch_ts;
+                .fill_market_feed_order::<false>(event.order_id, &self.depth)?;
+            let timestamp = event.exch_ts;
             for mut order in filled {
                 let price_tick = order.price_tick;
                 self.fill(&mut order, timestamp, true, price_tick)?;
             }
         }
 
-        // Checks
-        let mut next_ts = 0;
-        for rn in (self.row_num + 1)..self.data.len() {
-            if self.data[rn].is(EXCH_EVENT) {
-                self.row_num = rn;
-                next_ts = self.data[rn].exch_ts;
-                break;
-            }
-        }
-
-        if next_ts <= 0 {
-            let next_data = self.reader.next_data()?;
-            let next_row = &next_data[0];
-            next_ts = next_row.exch_ts;
-            let data = mem::replace(&mut self.data, next_data);
-            self.reader.release(data);
-            self.row_num = 0;
-        }
-        Ok((next_ts, i64::MAX))
+        Ok(())
     }
+}
 
+impl<AT, LM, QM, MD, FM> OrderConsumer for L3NoPartialFillExchange<AT, LM, QM, MD, FM>
+where
+    AT: AssetType,
+    LM: LatencyModel,
+    QM: L3QueueModel<MD>,
+    MD: L3MarketDepth,
+    FM: FeeModel,
+    BacktestError: From<<MD as L3MarketDepth>::Error>,
+{
     fn process_recv_order(
         &mut self,
         timestamp: i64,
@@ -455,11 +409,9 @@ where
         }
         Ok(false)
     }
-
     fn earliest_recv_order_timestamp(&self) -> i64 {
         self.orders_from.earliest_timestamp().unwrap_or(i64::MAX)
     }
-
     fn earliest_send_order_timestamp(&self) -> i64 {
         self.orders_to.earliest_timestamp().unwrap_or(i64::MAX)
     }

--- a/hftbacktest/src/backtest/proc/mod.rs
+++ b/hftbacktest/src/backtest/proc/mod.rs
@@ -91,7 +91,7 @@ where
 }
 
 /// Processes the historical feed data and the order interaction.
-pub trait Processor {
+pub trait Processor: OrderConsumer {
     /// Prepares to process the data. This is invoked when the backtesting is initiated.
     /// If successful, returns the timestamp of the first event.
     fn initialize_data(&mut self) -> Result<i64, BacktestError>;
@@ -100,7 +100,9 @@ pub trait Processor {
     /// event to be processed in the data.
     /// If successful, returns the timestamp of the next event.
     fn process_data(&mut self) -> Result<(i64, i64), BacktestError>;
+}
 
+pub trait OrderConsumer {
     /// Processes an order upon receipt. This is invoked when the backtesting time reaches the order
     /// receipt timestamp.
     /// Returns Ok(true) if the order with `wait_resp_order_id` is received and processed.
@@ -109,10 +111,8 @@ pub trait Processor {
         timestamp: i64,
         wait_resp_order_id: Option<OrderId>,
     ) -> Result<bool, BacktestError>;
-
     /// Returns the foremost timestamp at which an order is to be received by this processor.
     fn earliest_recv_order_timestamp(&self) -> i64;
-
     /// Returns the foremost timestamp at which an order sent by this processor is to be received by
     /// the corresponding processor.
     fn earliest_send_order_timestamp(&self) -> i64;

--- a/hftbacktest/src/backtest/proc/nopartialfillexchange.rs
+++ b/hftbacktest/src/backtest/proc/nopartialfillexchange.rs
@@ -6,13 +6,15 @@ use std::{
     rc::Rc,
 };
 
+use bus::BusReader;
+
 use crate::{
     backtest::{
         assettype::AssetType,
-        data::{Data, Reader},
+        data::{Data, EventBusMessage, EventConsumer, Reader, TimestampedEventQueue},
         models::{FeeModel, LatencyModel, QueueModel},
         order::OrderBus,
-        proc::Processor,
+        proc::{OrderConsumer, Processor},
         state::State,
         BacktestError,
     },
@@ -36,6 +38,7 @@ use crate::{
         EXCH_SELL_TRADE_EVENT,
     },
 };
+use crate::backtest::data::EventBusReader;
 
 /// The exchange model without partial fills.
 ///
@@ -70,8 +73,8 @@ where
     MD: MarketDepth,
     FM: FeeModel,
 {
-    reader: Reader<Event>,
-    data: Data<Event>,
+    reader: EventBusReader<Event>,
+    next: Option<Event>,
     row_num: usize,
 
     // key: order_id, value: Order<Q>
@@ -101,7 +104,7 @@ where
 {
     /// Constructs an instance of `NoPartialFillExchange`.
     pub fn new(
-        reader: Reader<Event>,
+        reader: EventBusReader<Event>,
         depth: MD,
         state: State<AT, FM>,
         order_latency: LM,
@@ -111,7 +114,7 @@ where
     ) -> Self {
         Self {
             reader,
-            data: Data::empty(),
+            next: None,
             row_num: 0,
             orders: Default::default(),
             buy_orders: Default::default(),
@@ -595,7 +598,7 @@ where
     }
 }
 
-impl<AT, LM, QM, MD, FM> Processor for NoPartialFillExchange<AT, LM, QM, MD, FM>
+impl<AT, LM, QM, MD, FM> EventConsumer<Event> for NoPartialFillExchange<AT, LM, QM, MD, FM>
 where
     AT: AssetType,
     LM: LatencyModel,
@@ -603,54 +606,36 @@ where
     MD: MarketDepth + L2MarketDepth,
     FM: FeeModel,
 {
-    fn initialize_data(&mut self) -> Result<i64, BacktestError> {
-        self.data = self.reader.next_data()?;
-        for rn in 0..self.data.len() {
-            if self.data[rn].is(EXCH_EVENT) {
-                self.row_num = rn;
-                return Ok(self.data[rn].exch_ts);
-            }
-        }
-        Err(BacktestError::EndOfData)
+    fn is_event_relevant(event: &Event) -> bool {
+        event.is(EXCH_EVENT)
     }
 
-    fn process_data(&mut self) -> Result<(i64, i64), BacktestError> {
-        let row_num = self.row_num;
-        if self.data[row_num].is(EXCH_BID_DEPTH_CLEAR_EVENT) {
-            self.depth.clear_depth(Side::Buy, self.data[row_num].px);
-        } else if self.data[row_num].is(EXCH_ASK_DEPTH_CLEAR_EVENT) {
-            self.depth.clear_depth(Side::Sell, self.data[row_num].px);
-        } else if self.data[row_num].is(EXCH_DEPTH_CLEAR_EVENT) {
+    fn process_event(&mut self, event: Event) -> Result<(), BacktestError> {
+        if event.is(EXCH_BID_DEPTH_CLEAR_EVENT) {
+            self.depth.clear_depth(Side::Buy, event.px);
+        } else if event.is(EXCH_ASK_DEPTH_CLEAR_EVENT) {
+            self.depth.clear_depth(Side::Sell, event.px);
+        } else if event.is(EXCH_DEPTH_CLEAR_EVENT) {
             self.depth.clear_depth(Side::None, 0.0);
-        } else if self.data[row_num].is(EXCH_BID_DEPTH_EVENT)
-            || self.data[row_num].is(EXCH_BID_DEPTH_SNAPSHOT_EVENT)
-        {
+        } else if event.is(EXCH_BID_DEPTH_EVENT) || event.is(EXCH_BID_DEPTH_SNAPSHOT_EVENT) {
             let (price_tick, prev_best_bid_tick, best_bid_tick, prev_qty, new_qty, timestamp) =
-                self.depth.update_bid_depth(
-                    self.data[row_num].px,
-                    self.data[row_num].qty,
-                    self.data[row_num].exch_ts,
-                );
+                self.depth
+                    .update_bid_depth(event.px, event.qty, event.exch_ts);
             self.on_bid_qty_chg(price_tick, prev_qty, new_qty);
             if best_bid_tick > prev_best_bid_tick {
                 self.on_best_bid_update(prev_best_bid_tick, best_bid_tick, timestamp)?;
             }
-        } else if self.data[row_num].is(EXCH_ASK_DEPTH_EVENT)
-            || self.data[row_num].is(EXCH_ASK_DEPTH_SNAPSHOT_EVENT)
-        {
+        } else if event.is(EXCH_ASK_DEPTH_EVENT) || event.is(EXCH_ASK_DEPTH_SNAPSHOT_EVENT) {
             let (price_tick, prev_best_ask_tick, best_ask_tick, prev_qty, new_qty, timestamp) =
-                self.depth.update_ask_depth(
-                    self.data[row_num].px,
-                    self.data[row_num].qty,
-                    self.data[row_num].exch_ts,
-                );
+                self.depth
+                    .update_ask_depth(event.px, event.qty, event.exch_ts);
             self.on_ask_qty_chg(price_tick, prev_qty, new_qty);
             if best_ask_tick < prev_best_ask_tick {
                 self.on_best_ask_update(prev_best_ask_tick, best_ask_tick, timestamp)?;
             }
-        } else if self.data[row_num].is(EXCH_BUY_TRADE_EVENT) {
-            let price_tick = (self.data[row_num].px / self.depth.tick_size()).round() as i64;
-            let qty = self.data[row_num].qty;
+        } else if event.is(EXCH_BUY_TRADE_EVENT) {
+            let price_tick = (event.px / self.depth.tick_size()).round() as i64;
+            let qty = event.qty;
             {
                 let orders = self.orders.clone();
                 let mut orders_borrowed = orders.borrow_mut();
@@ -659,12 +644,7 @@ where
                 {
                     for (_, order) in orders_borrowed.iter_mut() {
                         if order.side == Side::Sell {
-                            self.check_if_sell_filled(
-                                order,
-                                price_tick,
-                                qty,
-                                self.data[row_num].exch_ts,
-                            )?;
+                            self.check_if_sell_filled(order, price_tick, qty, event.exch_ts)?;
                         }
                     }
                 } else {
@@ -672,21 +652,16 @@ where
                         if let Some(order_ids) = self.sell_orders.get(&t) {
                             for order_id in order_ids.clone().iter() {
                                 let order = orders_borrowed.get_mut(order_id).unwrap();
-                                self.check_if_sell_filled(
-                                    order,
-                                    price_tick,
-                                    qty,
-                                    self.data[row_num].exch_ts,
-                                )?;
+                                self.check_if_sell_filled(order, price_tick, qty, event.exch_ts)?;
                             }
                         }
                     }
                 }
             }
             self.remove_filled_orders();
-        } else if self.data[row_num].is(EXCH_SELL_TRADE_EVENT) {
-            let price_tick = (self.data[row_num].px / self.depth.tick_size()).round() as i64;
-            let qty = self.data[row_num].qty;
+        } else if event.is(EXCH_SELL_TRADE_EVENT) {
+            let price_tick = (event.px / self.depth.tick_size()).round() as i64;
+            let qty = event.qty;
             {
                 let orders = self.orders.clone();
                 let mut orders_borrowed = orders.borrow_mut();
@@ -695,12 +670,7 @@ where
                 {
                     for (_, order) in orders_borrowed.iter_mut() {
                         if order.side == Side::Buy {
-                            self.check_if_buy_filled(
-                                order,
-                                price_tick,
-                                qty,
-                                self.data[row_num].exch_ts,
-                            )?;
+                            self.check_if_buy_filled(order, price_tick, qty, event.exch_ts)?;
                         }
                     }
                 } else {
@@ -708,12 +678,7 @@ where
                         if let Some(order_ids) = self.buy_orders.get(&t) {
                             for order_id in order_ids.clone().iter() {
                                 let order = orders_borrowed.get_mut(order_id).unwrap();
-                                self.check_if_buy_filled(
-                                    order,
-                                    price_tick,
-                                    qty,
-                                    self.data[row_num].exch_ts,
-                                )?;
+                                self.check_if_buy_filled(order, price_tick, qty, event.exch_ts)?;
                             }
                         }
                     }
@@ -722,27 +687,67 @@ where
             self.remove_filled_orders();
         }
 
-        // Checks
-        let mut next_ts = 0;
-        for rn in (self.row_num + 1)..self.data.len() {
-            if self.data[rn].is(EXCH_EVENT) {
-                self.row_num = rn;
-                next_ts = self.data[rn].exch_ts;
-                break;
+        Ok(())
+    }
+}
+
+impl<ExchT> Processor for ExchT
+where
+    ExchT: OrderConsumer + EventConsumer<Event> + TimestampedEventQueue<Event>,
+{
+    fn initialize_data(&mut self) -> Result<i64, BacktestError> {
+        while let Some(event) = self.peek_event() {
+            if Self::is_event_relevant(event) {
+                let ts = Self::event_time(event);
+                return Ok(ts);
             }
+
+            // Consume the peeked event.
+            let _ = self.next_event();
         }
 
-        if next_ts <= 0 {
-            let next_data = self.reader.next_data()?;
-            let next_row = &next_data[0];
-            next_ts = next_row.exch_ts;
-            let data = mem::replace(&mut self.data, next_data);
-            self.reader.release(data);
-            self.row_num = 0;
-        }
-        Ok((next_ts, i64::MAX))
+        Err(BacktestError::EndOfData)
     }
 
+    fn process_data(&mut self) -> Result<(i64, i64), BacktestError> {
+        let current = self.next_event().ok_or(BacktestError::EndOfData)?;
+        self.process_event(current)?;
+        let next = self.peek_event().ok_or(BacktestError::EndOfData)?;
+        let next_ts = Self::event_time(&next);
+
+        Ok((next_ts, i64::MAX))
+    }
+}
+
+impl<AT, LM, QM, MD, FM> TimestampedEventQueue<Event> for NoPartialFillExchange<AT, LM, QM, MD, FM>
+where
+    AT: AssetType,
+    LM: LatencyModel,
+    QM: QueueModel<MD>,
+    MD: MarketDepth + L2MarketDepth,
+    FM: FeeModel,
+{
+    fn next_event(&mut self) -> Option<Event> {
+        self.reader.next()
+    }
+
+    fn peek_event(&mut self) -> Option<&Event> {
+        self.reader.peek()
+    }
+
+    fn event_time(value: &Event) -> i64 {
+        value.exch_ts
+    }
+}
+
+impl<AT, LM, QM, MD, FM> OrderConsumer for NoPartialFillExchange<AT, LM, QM, MD, FM>
+where
+    AT: AssetType,
+    LM: LatencyModel,
+    QM: QueueModel<MD>,
+    MD: MarketDepth + L2MarketDepth,
+    FM: FeeModel,
+{
     fn process_recv_order(
         &mut self,
         timestamp: i64,
@@ -761,11 +766,9 @@ where
         }
         Ok(false)
     }
-
     fn earliest_recv_order_timestamp(&self) -> i64 {
         self.orders_from.earliest_timestamp().unwrap_or(i64::MAX)
     }
-
     fn earliest_send_order_timestamp(&self) -> i64 {
         self.orders_to.earliest_timestamp().unwrap_or(i64::MAX)
     }


### PR DESCRIPTION
Remove the `read_data()` calls within the backtest implementations and replace them with `recv()` calls on a lock-free queue. This avoids the pause that happened previously when a backtest reaches the end of the current periods data and begins loading the next file. With this model, the data for the next period should be available by the time the previous one finishes.

There are still a couple of improvements that need to be made here:

- `Clone` is unnecessary, readers could easily accept a reference to `Event`
- Files still need to be read in their entirety before they are sent down the bus. 