### PR TITLE
immutable recorder

### DIFF
--- a/hftbacktest/src/backtest/recorder.rs
+++ b/hftbacktest/src/backtest/recorder.rs
@@ -37,7 +37,7 @@ pub struct BacktestRecorder {
 impl Recorder for BacktestRecorder {
     type Error = Error;
 
-    fn record<MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
+    fn record<MD, I>(&mut self, hbt: &I) -> Result<(), Self::Error>
     where
         MD: MarketDepth,
         I: Bot<MD>,

--- a/hftbacktest/src/live/recorder.rs
+++ b/hftbacktest/src/live/recorder.rs
@@ -17,7 +17,7 @@ pub struct LoggingRecorder {
 impl Recorder for LoggingRecorder {
     type Error = ();
 
-    fn record<MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
+    fn record<MD, I>(&mut self, hbt: &I) -> Result<(), Self::Error>
     where
         MD: MarketDepth,
         I: Bot<MD>,

--- a/hftbacktest/src/types.rs
+++ b/hftbacktest/src/types.rs
@@ -955,7 +955,7 @@ pub trait Recorder {
     type Error;
 
     /// Records the current [`StateValues`].
-    fn record<MD, I>(&mut self, hbt: &mut I) -> Result<(), Self::Error>
+    fn record<MD, I>(&mut self, hbt: &I) -> Result<(), Self::Error>
     where
         I: Bot<MD>,
         MD: MarketDepth;


### PR DESCRIPTION
I feel a bit strange with loggers, that require mutable object. Should they work with immutable, maybe?