### PR TITLE
Use buffered writing to write records

### DIFF
--- a/hftbacktest/src/backtest/recorder.rs
+++ b/hftbacktest/src/backtest/recorder.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{Error, Write, BufWriter},
+    io::{Error, Write},
     path::Path,
 };
 
@@ -91,33 +91,37 @@ impl BacktestRecorder {
         P: AsRef<Path>,
     {
         let prefix = prefix.as_ref();
-        let base_path = path.as_ref();
-
-        // Buffer output to reduce frequent file I/O
         for (asset_no, values) in self.values.iter().enumerate() {
-            let file_path = base_path.join(format!("{prefix}{asset_no}.csv"));
-            // Use BufWriter for buffered writing
-            let mut file = BufWriter::new(File::create(file_path)?);
-
-            // Write header
-            file.write_all(
-                b"timestamp,balance,position,fee,trading_volume,trading_value,num_trades,price\n",
+            let file_path = path.as_ref().join(format!("{prefix}{asset_no}.csv"));
+            let mut file = File::create(file_path)?;
+            writeln!(
+                file,
+                "timestamp,balance,position,fee,trading_volume,trading_value,num_trades,price",
             )?;
-
-            // Write records
-            for record in values {
-                let line = format!(
-                    "{},{},{},{},{},{},{},{}\n",
-                    record.timestamp,
-                    record.balance,
-                    record.position,
-                    record.fee,
-                    record.trading_volume,
-                    record.trading_value,
-                    record.num_trades,
-                    record.price,
-                );
-                file.write_all(line.as_bytes())?;
+            for Record {
+                timestamp,
+                balance,
+                position,
+                fee,
+                trading_volume,
+                trading_value,
+                num_trades,
+                price: mid_price,
+            } in values
+            {
+                writeln!(
+                    file,
+                    "{},{},{},{},{},{},{},{}",
+                    timestamp,
+                    balance,
+                    position,
+                    fee,
+                    trading_volume,
+                    trading_value,
+                    num_trades,
+                    mid_price,
+                )?;
+            }
         }
         Ok(())
     }

--- a/hftbacktest/src/backtest/recorder.rs
+++ b/hftbacktest/src/backtest/recorder.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{Error, Write},
+    io::{BufWriter, Error, Write},
     path::Path,
 };
 
@@ -93,7 +93,7 @@ impl BacktestRecorder {
         let prefix = prefix.as_ref();
         for (asset_no, values) in self.values.iter().enumerate() {
             let file_path = path.as_ref().join(format!("{prefix}{asset_no}.csv"));
-            let mut file = File::create(file_path)?;
+            let mut file = BufWriter::new(File::create(file_path)?);
             writeln!(
                 file,
                 "timestamp,balance,position,fee,trading_volume,trading_value,num_trades,price",


### PR DESCRIPTION
I noticed that writing backtest results to csv takes a long time for large assets such as BTCUSDT. This PR uses buffered writing to speed-up the writing significantly.