### PR TITLE
fix(rust): fix overflow when subtracting durations

### DIFF
--- a/hftbacktest/src/live/bot.rs
+++ b/hftbacktest/src/live/bot.rs
@@ -350,7 +350,9 @@ where
             if !batch_mode && elapsed > duration {
                 return Ok(ElapseResult::Ok);
             }
-            remaining_duration = (duration - elapsed).max(Duration::from_micros(1));
+            remaining_duration = duration
+                .saturating_sub(elapsed)
+                .max(Duration::from_micros(1));
         }
     }
 


### PR DESCRIPTION
In LiveBot `elapse_`, after total duration elapsed in batch mode, subtracting elapsed from duration would cause overflow panic.  Use saturating_sub to prevent panic.