### PR TITLE
Add Hyperliquid to data collector

### DIFF
--- a/collector/src/hyperliquid/http.rs
+++ b/collector/src/hyperliquid/http.rs
@@ -1,0 +1,162 @@
+use std::{
+    io,
+    io::ErrorKind,
+    time::{Duration, Instant},
+};
+
+use anyhow::Error;
+use chrono::{DateTime, Utc};
+use futures_util::{SinkExt, StreamExt};
+use tokio::{
+    select,
+    sync::mpsc::{UnboundedSender, unbounded_channel},
+};
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Message, Utf8Bytes, client::IntoClientRequest},
+};
+use tracing::{error, info, warn};
+
+pub async fn connect(
+    url: &str,
+    subscriptions: Vec<serde_json::Value>,
+    ws_tx: UnboundedSender<(DateTime<Utc>, Utf8Bytes)>,
+) -> Result<(), anyhow::Error> {
+    let request = url.into_client_request()?;
+    let (ws_stream, _) = connect_async(request).await?;
+    let (mut write, mut read) = ws_stream.split();
+    let (_ping_tx, mut ping_rx) = unbounded_channel::<()>();
+
+    for subscription in subscriptions {
+        write
+            .send(Message::Text(subscription.to_string().into()))
+            .await?;
+    }
+
+    tokio::spawn(async move {
+        let mut ping_interval = tokio::time::interval(Duration::from_secs(30));
+        loop {
+            select! {
+                _ = ping_interval.tick() => {
+                    if write.send(Message::Text(r#"{"method":"ping"}"#.into())).await.is_err() {
+                        return;
+                    }
+                }
+                result = ping_rx.recv() => {
+                    if result.is_none() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+
+    loop {
+        match read.next().await {
+            Some(Ok(Message::Text(text))) => {
+                let recv_time = Utc::now();
+
+                if let Ok(j) = serde_json::from_str::<serde_json::Value>(&text) {
+                    if j.get("channel").and_then(|c| c.as_str()) == Some("pong") {
+                        continue;
+                    }
+                }
+
+                if ws_tx.send((recv_time, text)).is_err() {
+                    break;
+                }
+            }
+            Some(Ok(Message::Binary(_))) => {}
+            Some(Ok(Message::Ping(_))) => {
+                // Hyperliquid uses JSON ping/pong, not WebSocket ping/pong
+            }
+            Some(Ok(Message::Pong(_))) => {}
+            Some(Ok(Message::Close(close_frame))) => {
+                warn!(?close_frame, "connection closed");
+                return Err(Error::from(io::Error::new(
+                    ErrorKind::ConnectionAborted,
+                    "connection closed",
+                )));
+            }
+            Some(Ok(Message::Frame(_))) => {}
+            Some(Err(e)) => {
+                return Err(Error::from(e));
+            }
+            None => {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn keep_connection(
+    subscription_types: Vec<String>,
+    symbol_list: Vec<String>,
+    ws_tx: UnboundedSender<(DateTime<Utc>, Utf8Bytes)>,
+) {
+    let mut error_count = 0;
+    loop {
+        let connect_time = Instant::now();
+
+        let subscriptions: Vec<serde_json::Value> = symbol_list
+            .iter()
+            .flat_map(|symbol| {
+                subscription_types
+                    .iter()
+                    .map(move |sub_type| match sub_type.as_str() {
+                        "trades" => serde_json::json!({
+                            "method": "subscribe",
+                            "subscription": {
+                                "type": "trades",
+                                "coin": symbol
+                            }
+                        }),
+                        "l2Book" => serde_json::json!({
+                            "method": "subscribe",
+                            "subscription": {
+                                "type": "l2Book",
+                                "coin": symbol
+                            }
+                        }),
+                        _ => serde_json::json!({
+                            "method": "subscribe",
+                            "subscription": {
+                                "type": sub_type,
+                                "coin": symbol
+                            }
+                        }),
+                    })
+            })
+            .collect();
+
+        info!(
+            "Connecting to Hyperliquid WebSocket with {} subscriptions",
+            subscriptions.len()
+        );
+
+        if let Err(error) =
+            connect("wss://api.hyperliquid.xyz/ws", subscriptions, ws_tx.clone()).await
+        {
+            error!(?error, "websocket error");
+            error_count += 1;
+            if connect_time.elapsed() > Duration::from_secs(30) {
+                error_count = 0;
+            }
+
+            let sleep_duration = if error_count > 20 {
+                Duration::from_secs(10)
+            } else if error_count > 10 {
+                Duration::from_secs(5)
+            } else if error_count > 3 {
+                Duration::from_secs(1)
+            } else {
+                Duration::from_millis(500)
+            };
+
+            tokio::time::sleep(sleep_duration).await;
+        } else {
+            break;
+        }
+    }
+}

--- a/collector/src/hyperliquid/mod.rs
+++ b/collector/src/hyperliquid/mod.rs
@@ -1,0 +1,76 @@
+mod http;
+
+use chrono::{DateTime, Utc};
+pub use http::keep_connection;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_tungstenite::tungstenite::Utf8Bytes;
+use tracing::error;
+
+use crate::error::ConnectorError;
+
+fn handle(
+    writer_tx: &UnboundedSender<(DateTime<Utc>, String, String)>,
+    recv_time: DateTime<Utc>,
+    data: Utf8Bytes,
+) -> Result<(), ConnectorError> {
+    let j: serde_json::Value = serde_json::from_str(data.as_str())?;
+
+    if let Some(channel) = j.get("channel") {
+        let channel_str = channel.as_str().ok_or(ConnectorError::FormatError)?;
+
+        if channel_str == "subscriptionResponse" {
+            return Ok(());
+        }
+
+        if let Some(data_obj) = j.get("data") {
+            let symbol = match channel_str {
+                "trades" => {
+                    if let Some(trades) = data_obj.as_array() {
+                        if let Some(first_trade) = trades.first() {
+                            first_trade
+                                .get("coin")
+                                .and_then(|c| c.as_str())
+                                .ok_or(ConnectorError::FormatError)?
+                        } else {
+                            return Ok(());
+                        }
+                    } else {
+                        return Err(ConnectorError::FormatError);
+                    }
+                }
+                "l2Book" => data_obj
+                    .get("coin")
+                    .and_then(|c| c.as_str())
+                    .ok_or(ConnectorError::FormatError)?,
+                _ => {
+                    if let Some(coin) = data_obj.get("coin").and_then(|c| c.as_str()) {
+                        coin
+                    } else {
+                        return Ok(());
+                    }
+                }
+            };
+
+            let _ = writer_tx.send((recv_time, symbol.to_string(), data.to_string()));
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn run_collection(
+    subscriptions: Vec<String>,
+    symbols: Vec<String>,
+    writer_tx: UnboundedSender<(DateTime<Utc>, String, String)>,
+) -> Result<(), anyhow::Error> {
+    let (ws_tx, mut ws_rx) = tokio::sync::mpsc::unbounded_channel();
+    let h = tokio::spawn(keep_connection(subscriptions, symbols, ws_tx.clone()));
+
+    while let Some((recv_time, data)) = ws_rx.recv().await {
+        if let Err(error) = handle(&writer_tx, recv_time, data) {
+            error!(?error, "couldn't handle the received data.");
+        }
+    }
+    let _ = h.await;
+    Ok(())
+}

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -11,6 +11,7 @@ mod binancefuturesum;
 mod bybit;
 mod error;
 mod file;
+mod hyperliquid;
 mod throttler;
 
 #[derive(Parser, Debug)]
@@ -89,6 +90,18 @@ async fn main() -> Result<(), anyhow::Error> {
             .collect();
 
             tokio::spawn(bybit::run_collection(topics, args.symbols, writer_tx))
+        }
+        "hyperliquid" => {
+            let subscriptions = ["trades", "l2Book"]
+                .iter()
+                .map(|sub| sub.to_string())
+                .collect();
+
+            tokio::spawn(hyperliquid::run_collection(
+                subscriptions,
+                args.symbols,
+                writer_tx,
+            ))
         }
         exchange => {
             return Err(anyhow!("{exchange} is not supported."));


### PR DESCRIPTION
First of all, thank you so much for sharing this project as open source.

I noticed there was a Hyperliquid data converter available but no data collector, so I'm submitting this PR.

### Usage

1. perpetual:

```bash
./target/release/collect-data ./data/ hyperliquid BTC ETH SOL
```

2. spot:

Use indices to specify assets, for example:

* BTC: index `197`
* ETH: index `221`
* SOL: index `254`

These indices can be retrieved via the [Retrieve spot metadata api](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/spot#retrieve-spot-metadata)

example:

```bash
./target/release/collect-data ./data/ hyperliquid @197 @221 @254
```

### Normalization code example

```python
from hftbacktest.data.utils import hyperliquid

_ = hyperliquid.convert(
    "data/btc_20250529.gz",
    output_filename="npz/btc_20250529.npz",
    num_levels=20,
    tick_size=0.1,
    lot_size=0.00001,
)
```

#### Lot size and tick size calculations

```python
lot_size = 10 ** (-szDecimals)
tick_size = 10 ** (-(MAX_DECIMALS - szDecimals))
```

Note:

* MAX_DECIMALS is 6 for perpetuals and 8 for spot.
* szDecimals retrieval:
    * Perpetuals: [Perpetuals Metadata API](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals#retrieve-perpetuals-metadata-universe-and-margin-tables)
    * Spot: [Spot Metadata API](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/spot#retrieve-spot-metadata)

The num_levels parameter isn't explicitly stated in the WebSocket documentation, but according to the [l2-book-snapshot post api documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint#l2-book-snapshot), it appears to be 20.