### PR TITLE
fix potential flag contamination.

### DIFF
--- a/py-hftbacktest/hftbacktest/data/validation.py
+++ b/py-hftbacktest/hftbacktest/data/validation.py
@@ -104,7 +104,7 @@ def correct_event_order(
         )):
             # exchange
             sorted_final[out_rn] = sorted_exch
-            sorted_final[out_rn].ev = sorted_final[out_rn].ev | EXCH_EVENT
+            sorted_final[out_rn].ev = sorted_final[out_rn].ev & ~LOCAL_EVENT | EXCH_EVENT
 
             out_rn += 1
             exch_rn += 1
@@ -118,14 +118,14 @@ def correct_event_order(
         )):
             # local
             sorted_final[out_rn] = sorted_local
-            sorted_final[out_rn].ev = sorted_final[out_rn].ev | LOCAL_EVENT
+            sorted_final[out_rn].ev = sorted_final[out_rn].ev & ~EXCH_EVENT | LOCAL_EVENT
 
             out_rn += 1
             local_rn += 1
         elif exch_rn < len(data):
             # exchange
             sorted_final[out_rn] = sorted_exch
-            sorted_final[out_rn].ev = sorted_final[out_rn].ev | EXCH_EVENT
+            sorted_final[out_rn].ev = sorted_final[out_rn].ev & ~LOCAL_EVENT | EXCH_EVENT
 
             out_rn += 1
             exch_rn += 1


### PR DESCRIPTION
Hi, the function correct_event_order might subject to flag contamination, maybe unset some flags?

like : 
```python3
sorted_final[out_rn].ev = sorted_final[out_rn].ev | LOCAL_EVENT
```

If an event has previously been tagged with `EXCH_EVENT`, we do not want it to continue to carry that exchange flag after we have reclassified it as purely local. In corner cases (e.g. custom ingestion scripts), ev | LOCAL_EVENT will leave EXCH_EVENT set, causing ambiguity downstream.

a maybe more safe implementation : 
```python3
sorted_final[out_rn].ev = sorted_final[out_rn].ev & ~EXCH_EVENT | LOCAL_EVENT
```

I think the old implementation is safe under the tardis data ingestion workload, but this would make the code more robust if someone might want to do a little customization.