### PR TITLE
Improve DataError

### DIFF
--- a/hftbacktest/src/backtest/data/reader.rs
+++ b/hftbacktest/src/backtest/data/reader.rs
@@ -367,7 +367,10 @@ where
                     LoadDataResult {
                         result: Err(err), ..
                     } => {
-                        return Err(BacktestError::DataError(err));
+                        return Err(BacktestError::DataError(std::io::Error::new(
+                            err.kind(),
+                            format!("Failed to read file '{}': {}", key, err),
+                        )));
                     }
                 }
             }


### PR DESCRIPTION
## Goal

This PR aims to make the `DataError` message more informative in the backtest's reader. Instead of the current format, this proposed change adds the file that causes the issue. This is particularly helpful as it allows the user to quickly identify the root cause.

## Comparison (before & after):

### old

```
thread 'main' panicked at hftbacktest/src/backtest/models/latency.rs:227:37:
called `Result::unwrap()` on an `Err` value: DataError(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```

### new (proposed)

```
thread 'main' panicked at hftbacktest/src/backtest/models/latency.rs:227:37:
called `Result::unwrap()` on an `Err` value: DataError(Custom { kind: NotFound, error: "Failed to read file '/mnt/hft/streams/binance-futures/BTCUSDT/latency/binance-futures_BTCUSDT_20250516.npz': No such file or directory (os error 2)" })
```

Note the error message, `Failed to read file '/mnt/hft/streams/binance-futures/BTCUSDT/latency/binance-futures_BTCUSDT_20250516.npz': No such file or directory (os error 2)`