### PR TITLE
Add orderbook quantities

### DIFF
--- a/hftbacktest/src/depth/mod.rs
+++ b/hftbacktest/src/depth/mod.rs
@@ -29,9 +29,17 @@ pub trait MarketDepth {
     /// If there is no best bid, it returns [`f64::NAN`].
     fn best_bid(&self) -> f64;
 
+    /// Returns the best bid size.
+    /// If there is no best bid, it returns [`f64::NAN`].
+    fn best_bid_size(&self) -> f64;
+
     /// Returns the best ask price.
     /// If there is no best ask, it returns [`f64::NAN`].
     fn best_ask(&self) -> f64;
+
+    /// Returns the best ask size.
+    /// If there is no best ask, it returns [`f64::NAN`].
+    fn best_ask_size(&self) -> f64;
 
     /// Returns the best bid price in ticks.
     /// If there is no best bid, it returns [`INVALID_MIN`].
@@ -47,6 +55,9 @@ pub trait MarketDepth {
     /// Returns the quantity at the best ask price.
     fn best_ask_qty(&self) -> f64;
 
+    /// Returns the order book imbalance.
+    fn order_book_imbalance(&self) -> f64;
+
     /// Returns the tick size.
     fn tick_size(&self) -> f64;
 
@@ -58,6 +69,12 @@ pub trait MarketDepth {
 
     /// Returns the quantity at the ask market depth for a given price in ticks.
     fn ask_qty_at_tick(&self, price_tick: i64) -> f64;
+
+    /// Reverse-Weighted Spot
+    fn rws(&self) -> f64;
+
+    /// Mid Price
+    fn mid_price(&self) -> f64;
 }
 
 /// Provides Level2-specific market depth functions.

--- a/hftbacktest/src/depth/roivectormarketdepth.rs
+++ b/hftbacktest/src/depth/roivectormarketdepth.rs
@@ -24,6 +24,9 @@ pub struct ROIVectorMarketDepth {
     pub high_ask_tick: i64,
     pub roi_ub: i64,
     pub roi_lb: i64,
+    pub best_bid_size: f64,
+    pub best_ask_size: f64,
+    pub order_book_imbalance: f64,
     pub orders: HashMap<OrderId, L3Order>,
 }
 
@@ -77,6 +80,9 @@ impl ROIVectorMarketDepth {
             high_ask_tick: INVALID_MIN,
             roi_lb,
             roi_ub,
+            best_ask_size: 0.,
+            best_bid_size: 0.,
+            order_book_imbalance: 0.,
             orders: HashMap::new(),
         }
     }
@@ -430,6 +436,48 @@ impl MarketDepth for ROIVectorMarketDepth {
     #[inline(always)]
     fn lot_size(&self) -> f64 {
         self.lot_size
+    }
+
+    #[inline(always)]
+    fn best_ask_size(&self) -> f64 {
+        if self.best_ask_tick == INVALID_MIN {
+            f64::NAN
+        } else {
+            self.ask_qty_at_tick(self.best_ask_tick)
+        }
+    }
+
+    #[inline(always)]
+    fn best_bid_size(&self) -> f64 {
+        if self.best_bid_tick == INVALID_MIN {
+            f64::NAN
+        } else {
+            self.bid_qty_at_tick(self.best_bid_tick)
+        }
+    }
+
+    #[inline(always)]
+    fn rws(&self) -> f64 {
+        let term1 = self.best_ask() * self.best_bid_size();
+        let term2 = self.best_bid() * self.best_ask_size();
+        let term3 = self.best_ask_size() + self.best_bid_size();
+        if term3 > 0. {
+            return (term1 + term2) / term3;
+        } else {
+            return 0.0;
+        }
+    }
+
+    #[inline(always)]
+    fn mid_price(&self) -> f64 {
+        return (self.best_ask() + self.best_bid()) as f64 / 2.0;
+    }
+
+    #[inline(always)]
+    fn order_book_imbalance(&self) -> f64 {
+        let bid_size = self.best_bid_size();
+        let ask_size = self.best_ask_size();
+        (bid_size - ask_size) / (bid_size + ask_size)
     }
 
     #[inline(always)]


### PR DESCRIPTION
This pull requests adds the following functionality:
- size of best bid (`depth(i).best_bid_size()`)
- size of best ask (`depth(i).best_ask_size()`)
- RWS, aka reverse-weighted spot, a very common definition of the "micro-price" (`depth(i).rws()`)
- order book imbalance, a very common predictor (`depth(i).order_book_imbalance()`)
- mid price, (`depth(i).mid_price()`)