### PR TITLE
Add message counting and last trade information

### DIFF
--- a/hftbacktest/src/backtest/mod.rs
+++ b/hftbacktest/src/backtest/mod.rs
@@ -889,12 +889,25 @@ where
         self.local.get(asset_no).unwrap().state_values()
     }
 
+    #[inline]
+    fn mutable_state_values(&mut self, asset_no: usize) -> &mut StateValues {
+        self.local.get_mut(asset_no).unwrap().state_values_mut()
+    }
+
     fn depth(&self, asset_no: usize) -> &MD {
         self.local.get(asset_no).unwrap().depth()
     }
 
     fn last_trades(&self, asset_no: usize) -> &[Event] {
         self.local.get(asset_no).unwrap().last_trades()
+    }
+
+    fn last_trade_price(&self, asset_no: usize) -> f64 {
+        self.local.get(asset_no).unwrap().last_trade_price()
+    }
+
+    fn last_trade_size(&self, asset_no: usize) -> f64 {
+        self.local.get(asset_no).unwrap().last_trade_size()
     }
 
     #[inline]

--- a/hftbacktest/src/backtest/proc/mod.rs
+++ b/hftbacktest/src/backtest/proc/mod.rs
@@ -80,6 +80,9 @@ where
     /// Returns the state's values such as balance, fee, and so on.
     fn state_values(&self) -> &StateValues;
 
+    /// Returns the state's values such as balance, fee, and so on, mutable.
+    fn state_values_mut(&mut self) -> &mut StateValues;
+
     /// Returns the [`MarketDepth`].
     fn depth(&self) -> &MD;
 
@@ -88,6 +91,12 @@ where
 
     /// Returns the last market trades.
     fn last_trades(&self) -> &[Event];
+
+    /// Returns the last trade's price
+    fn last_trade_price(&self) -> f64;
+
+    /// Returns the last trade's size
+    fn last_trade_size(&self) -> f64;
 
     /// Clears the last market trades from the buffer.
     fn clear_last_trades(&mut self);

--- a/hftbacktest/src/backtest/state.rs
+++ b/hftbacktest/src/backtest/state.rs
@@ -28,6 +28,10 @@ where
                 num_trades: 0,
                 trading_volume: 0.0,
                 trading_value: 0.0,
+                num_messages: 0,
+                num_creations: 0,
+                num_modifications: 0,
+                num_cancellations: 0,
             },
             fee_model,
             asset_type,
@@ -41,6 +45,7 @@ where
         self.state_values.balance -= amount * AsRef::<f64>::as_ref(&order.side);
         self.state_values.fee += self.fee_model.amount(order, amount);
         self.state_values.num_trades += 1;
+        self.state_values.num_messages += 1;
         self.state_values.trading_volume += order.exec_qty;
         self.state_values.trading_value += amount;
     }
@@ -58,5 +63,10 @@ where
     #[inline]
     pub fn values(&self) -> &StateValues {
         &self.state_values
+    }
+
+    #[inline]
+    pub fn values_mut(&mut self) -> &mut StateValues {
+        &mut self.state_values
     }
 }

--- a/hftbacktest/src/live/bot.rs
+++ b/hftbacktest/src/live/bot.rs
@@ -172,12 +172,12 @@ impl<MD> LiveBotBuilder<MD> {
 /// Provides the same interface as the backtesters in [`backtest`](`crate::backtest`).
 ///
 /// ```
-/// use hftbacktest::{live::{Instrument, LiveBot}, prelude::HashMapMarketDepth};
+/// use hftbacktest::{live::{Instrument, LiveBotBuilder, ipc::iceoryx::IceoryxUnifiedChannel}, prelude::HashMapMarketDepth};
 ///
 /// let tick_size = 0.1;
 /// let lot_size = 1.0;
 ///
-/// let mut hbt = LiveBot::builder()
+/// let hbt: hftbacktest::live::LiveBot<IceoryxUnifiedChannel, HashMapMarketDepth> = LiveBotBuilder::new()
 ///     .register(Instrument::new(
 ///         "connector_name",
 ///         "symbol",
@@ -440,6 +440,11 @@ where
     }
 
     #[inline]
+    fn mutable_state_values(&mut self, asset_no: usize) -> &mut StateValues {
+        &mut self.instruments.get_mut(asset_no).unwrap().state
+    }
+
+    #[inline]
     fn depth(&self, asset_no: usize) -> &MD {
         &self.instruments.get(asset_no).unwrap().depth
     }
@@ -451,6 +456,24 @@ where
             .unwrap()
             .last_trades
             .as_slice()
+    }
+
+    #[inline]
+    fn last_trade_size(&self, asset_no: usize) -> f64 {
+        self.instruments
+            .get(asset_no)
+            .unwrap()
+            .last_trade_size
+            .clone()
+    }
+
+    #[inline]
+    fn last_trade_price(&self, asset_no: usize) -> f64 {
+        self.instruments
+            .get(asset_no)
+            .unwrap()
+            .last_trade_price
+            .clone()
     }
 
     fn clear_last_trades(&mut self, asset_no: Option<usize>) {

--- a/hftbacktest/src/live/mod.rs
+++ b/hftbacktest/src/live/mod.rs
@@ -24,6 +24,8 @@ pub struct Instrument<MD> {
     last_feed_latency: Option<(i64, i64)>,
     last_order_latency: Option<(i64, i64, i64)>,
     state: StateValues,
+    last_trade_size: f64,
+    last_trade_price: f64,
 }
 
 impl<MD> Instrument<MD> {
@@ -53,6 +55,8 @@ impl<MD> Instrument<MD> {
             last_feed_latency: None,
             last_order_latency: None,
             state: Default::default(),
+            last_trade_price: 0.0,
+            last_trade_size: 0.0,
         }
     }
 }

--- a/hftbacktest/src/types.rs
+++ b/hftbacktest/src/types.rs
@@ -459,6 +459,15 @@ impl AsRef<str> for OrdType {
 ///
 /// **Usage:**
 /// ```
+/// use hftbacktest::types::AnyClone;
+/// use std::any::Any;
+///
+/// // Define your custom data type
+/// #[derive(Clone)]
+/// struct QueuePos {
+///     pos: usize,
+/// }
+///
 /// impl AnyClone for QueuePos {
 ///     fn as_any(&self) -> &dyn Any {
 ///         self
@@ -746,6 +755,14 @@ pub struct StateValues {
     pub trading_volume: f64,
     /// Backtest only
     pub trading_value: f64,
+    /// Number of messages (backtest only)
+    pub num_messages: i64,
+    /// Number of quote cancellation messages (backtest only)
+    pub num_cancellations: i64,
+    /// Number of quote creation messages (backtest only)
+    pub num_creations: i64,
+    /// Number of modification messages (backtest only)
+    pub num_modifications: i64,
 }
 
 /// Provides errors that can occur in builders.
@@ -796,6 +813,9 @@ where
     /// Returns the state's values such as balance, fee, and so on.
     fn state_values(&self, asset_no: usize) -> &StateValues;
 
+    /// Returns the state's values such as balance, fee, and so on, mutable.
+    fn mutable_state_values(&mut self, asset_no: usize) -> &mut StateValues;
+
     /// Returns the [`MarketDepth`].
     ///
     /// * `asset_no` - Asset number from which the market depth will be retrieved.
@@ -805,6 +825,16 @@ where
     ///
     /// * `asset_no` - Asset number from which the last market trades will be retrieved.
     fn last_trades(&self, asset_no: usize) -> &[Event];
+
+    /// Returns the last trade's price
+    ///
+    /// * `asset_no` - Asset number from which the last market trades will be retrieved.
+    fn last_trade_price(&self, asset_no: usize) -> f64;
+
+    /// Returns the last trade's size
+    ///
+    /// * `asset_no` - Asset number from which the last market trades will be retrieved.
+    fn last_trade_size(&self, asset_no: usize) -> f64;
 
     /// Clears the last market trades from the buffer.
     ///


### PR DESCRIPTION
This PR adds:
- message counting: number of create messages sent, number of modification messages sent, number of cancellations sent
- last trade information: price and size

The number of messages allow us to compute the fraction of canceled quotes, which is important for some exchanges.