### PR TITLE
Add FXMacroData collector integration

### DIFF
--- a/collector/src/fxmacrodata.rs
+++ b/collector/src/fxmacrodata.rs
@@ -1,3 +1,5 @@
+//! FXMacroData collector integration for macro, FX, commodity, and rates data.
+
 use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Utc};
 use reqwest::{Client, Url};

--- a/collector/src/fxmacrodata.rs
+++ b/collector/src/fxmacrodata.rs
@@ -10,6 +10,7 @@ use tracing::info;
 
 const DEFAULT_BASE_URL: &str = "https://fxmacrodata.com/api/v1/";
 
+/// Client for FXMacroData REST and GraphQL endpoints.
 #[derive(Debug, Clone)]
 pub struct FxMacroDataClient {
     client: Client,
@@ -26,6 +27,8 @@ struct GraphQlRequest<'a> {
 }
 
 impl FxMacroDataClient {
+    /// Builds a client from the `FXMACRODATA_API_KEY` or `FXMD_API_KEY`
+    /// environment variable.
     pub fn from_env() -> Result<Self> {
         let api_key = std::env::var("FXMACRODATA_API_KEY")
             .or_else(|_| std::env::var("FXMD_API_KEY"))
@@ -33,11 +36,13 @@ impl FxMacroDataClient {
         Self::with_base_url(api_key, DEFAULT_BASE_URL)
     }
 
+    /// Builds a client using the default FXMacroData API URL.
     #[allow(dead_code)]
     pub fn new(api_key: impl Into<String>) -> Self {
         Self::with_base_url(api_key, DEFAULT_BASE_URL).expect("default FXMacroData URL is valid")
     }
 
+    /// Builds a client using a caller-supplied API base URL.
     pub fn with_base_url(api_key: impl Into<String>, base_url: &str) -> Result<Self> {
         Ok(Self {
             client: Client::new(),
@@ -46,16 +51,19 @@ impl FxMacroDataClient {
         })
     }
 
+    /// Sends a generic GET request to a relative FXMacroData API path.
     #[allow(dead_code)]
     pub async fn request(&self, path: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(path, params).await
     }
 
+    /// Retrieves the FXMacroData data catalogue for a currency.
     pub async fn data_catalogue(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("data_catalogue/{currency}"), params)
             .await
     }
 
+    /// Retrieves announcement history for a currency and indicator.
     pub async fn announcements(
         &self,
         currency: &str,
@@ -66,6 +74,7 @@ impl FxMacroDataClient {
             .await
     }
 
+    /// Retrieves the latest announcements for a currency.
     pub async fn latest_announcements(
         &self,
         currency: &str,
@@ -75,14 +84,17 @@ impl FxMacroDataClient {
             .await
     }
 
+    /// Retrieves recently changed announcement records.
     pub async fn announcement_changes(&self, params: &[(&str, String)]) -> Result<Value> {
         self.get_json("announcements/changes", params).await
     }
 
+    /// Retrieves the release calendar for a currency.
     pub async fn calendar(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("calendar/{currency}"), params).await
     }
 
+    /// Retrieves prediction data for a currency and indicator.
     pub async fn predictions(
         &self,
         currency: &str,
@@ -93,38 +105,46 @@ impl FxMacroDataClient {
             .await
     }
 
+    /// Retrieves FX spot history for a base/quote pair.
     pub async fn forex(&self, base: &str, quote: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("forex/{base}/{quote}"), params)
             .await
     }
 
+    /// Retrieves COT positioning data for a currency.
     pub async fn cot(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("cot/{currency}"), params).await
     }
 
+    /// Retrieves a commodity series by indicator slug.
     pub async fn commodity(&self, indicator: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("commodities/{indicator}"), params)
             .await
     }
 
+    /// Retrieves the latest commodity observations.
     pub async fn commodities_latest(&self, params: &[(&str, String)]) -> Result<Value> {
         self.get_json("commodities/latest", params).await
     }
 
+    /// Retrieves curve data for a currency.
     pub async fn curves(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("curves/{currency}"), params).await
     }
 
+    /// Retrieves curve proxy data for a currency.
     pub async fn curve_proxies(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("curve_proxies/{currency}"), params)
             .await
     }
 
+    /// Retrieves forward-curve data for a currency.
     pub async fn forward_curves(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("forward_curves/{currency}"), params)
             .await
     }
 
+    /// Retrieves rate differentials for a currency pair.
     pub async fn rate_differentials(
         &self,
         base: &str,
@@ -135,6 +155,7 @@ impl FxMacroDataClient {
             .await
     }
 
+    /// Retrieves forward-rate differentials for a currency pair.
     pub async fn forward_differentials(
         &self,
         base: &str,
@@ -145,23 +166,28 @@ impl FxMacroDataClient {
             .await
     }
 
+    /// Retrieves current FX market-session data.
     pub async fn market_sessions(&self, params: &[(&str, String)]) -> Result<Value> {
         self.get_json("market_sessions", params).await
     }
 
+    /// Retrieves current risk-sentiment data.
     pub async fn risk_sentiment(&self, params: &[(&str, String)]) -> Result<Value> {
         self.get_json("risk_sentiment", params).await
     }
 
+    /// Retrieves central-bank news for a currency.
     pub async fn news(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("news/{currency}"), params).await
     }
 
+    /// Retrieves central-bank press releases for a currency.
     pub async fn press_releases(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
         self.get_json(&format!("press-releases/{currency}"), params)
             .await
     }
 
+    /// Sends a GraphQL query to FXMacroData.
     #[allow(dead_code)]
     pub async fn graphql(&self, query: &str, variables: Option<Value>) -> Result<Value> {
         let url = self.build_url("graphql", &[])?;
@@ -217,6 +243,8 @@ impl FxMacroDataClient {
     }
 }
 
+/// Collects FXMacroData payloads for pairs, currencies, indicators, and
+/// commodities.
 pub async fn run_collection(
     symbols: Vec<String>,
     writer_tx: UnboundedSender<(DateTime<Utc>, String, String)>,

--- a/collector/src/fxmacrodata.rs
+++ b/collector/src/fxmacrodata.rs
@@ -1,0 +1,449 @@
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, Utc};
+use reqwest::{Client, Url};
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::info;
+
+const DEFAULT_BASE_URL: &str = "https://fxmacrodata.com/api/v1/";
+
+#[derive(Debug, Clone)]
+pub struct FxMacroDataClient {
+    client: Client,
+    api_key: String,
+    base_url: Url,
+}
+
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+struct GraphQlRequest<'a> {
+    query: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    variables: Option<Value>,
+}
+
+impl FxMacroDataClient {
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("FXMACRODATA_API_KEY")
+            .or_else(|_| std::env::var("FXMD_API_KEY"))
+            .context("FXMACRODATA_API_KEY or FXMD_API_KEY must be set")?;
+        Self::with_base_url(api_key, DEFAULT_BASE_URL)
+    }
+
+    #[allow(dead_code)]
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self::with_base_url(api_key, DEFAULT_BASE_URL).expect("default FXMacroData URL is valid")
+    }
+
+    pub fn with_base_url(api_key: impl Into<String>, base_url: &str) -> Result<Self> {
+        Ok(Self {
+            client: Client::new(),
+            api_key: api_key.into(),
+            base_url: Url::parse(base_url).context("invalid FXMacroData base URL")?,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub async fn request(&self, path: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(path, params).await
+    }
+
+    pub async fn data_catalogue(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("data_catalogue/{currency}"), params)
+            .await
+    }
+
+    pub async fn announcements(
+        &self,
+        currency: &str,
+        indicator: &str,
+        params: &[(&str, String)],
+    ) -> Result<Value> {
+        self.get_json(&format!("announcements/{currency}/{indicator}"), params)
+            .await
+    }
+
+    pub async fn latest_announcements(
+        &self,
+        currency: &str,
+        params: &[(&str, String)],
+    ) -> Result<Value> {
+        self.get_json(&format!("announcements/{currency}/latest"), params)
+            .await
+    }
+
+    pub async fn announcement_changes(&self, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json("announcements/changes", params).await
+    }
+
+    pub async fn calendar(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("calendar/{currency}"), params).await
+    }
+
+    pub async fn predictions(
+        &self,
+        currency: &str,
+        indicator: &str,
+        params: &[(&str, String)],
+    ) -> Result<Value> {
+        self.get_json(&format!("predictions/{currency}/{indicator}"), params)
+            .await
+    }
+
+    pub async fn forex(&self, base: &str, quote: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("forex/{base}/{quote}"), params)
+            .await
+    }
+
+    pub async fn cot(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("cot/{currency}"), params).await
+    }
+
+    pub async fn commodity(&self, indicator: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("commodities/{indicator}"), params)
+            .await
+    }
+
+    pub async fn commodities_latest(&self, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json("commodities/latest", params).await
+    }
+
+    pub async fn curves(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("curves/{currency}"), params).await
+    }
+
+    pub async fn curve_proxies(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("curve_proxies/{currency}"), params)
+            .await
+    }
+
+    pub async fn forward_curves(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("forward_curves/{currency}"), params)
+            .await
+    }
+
+    pub async fn rate_differentials(
+        &self,
+        base: &str,
+        quote: &str,
+        params: &[(&str, String)],
+    ) -> Result<Value> {
+        self.get_json(&format!("rate_differentials/{base}/{quote}"), params)
+            .await
+    }
+
+    pub async fn forward_differentials(
+        &self,
+        base: &str,
+        quote: &str,
+        params: &[(&str, String)],
+    ) -> Result<Value> {
+        self.get_json(&format!("forward_differentials/{base}/{quote}"), params)
+            .await
+    }
+
+    pub async fn market_sessions(&self, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json("market_sessions", params).await
+    }
+
+    pub async fn risk_sentiment(&self, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json("risk_sentiment", params).await
+    }
+
+    pub async fn news(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("news/{currency}"), params).await
+    }
+
+    pub async fn press_releases(&self, currency: &str, params: &[(&str, String)]) -> Result<Value> {
+        self.get_json(&format!("press-releases/{currency}"), params)
+            .await
+    }
+
+    #[allow(dead_code)]
+    pub async fn graphql(&self, query: &str, variables: Option<Value>) -> Result<Value> {
+        let url = self.build_url("graphql", &[])?;
+        let response = self
+            .client
+            .post(url.clone())
+            .json(&GraphQlRequest { query, variables })
+            .send()
+            .await
+            .context("FXMacroData GraphQL request failed")?;
+
+        Self::parse_response(response, url.as_str()).await
+    }
+
+    async fn get_json(&self, path: &str, params: &[(&str, String)]) -> Result<Value> {
+        let url = self.build_url(path, params)?;
+        let response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .context("FXMacroData request failed")?;
+
+        Self::parse_response(response, url.as_str()).await
+    }
+
+    fn build_url(&self, path: &str, params: &[(&str, String)]) -> Result<Url> {
+        let mut url = self
+            .base_url
+            .join(path.trim_start_matches('/'))
+            .context("failed to build FXMacroData URL")?;
+        {
+            let mut query = url.query_pairs_mut();
+            for (key, value) in params {
+                query.append_pair(key, value);
+            }
+            query.append_pair("api_key", &self.api_key);
+        }
+        Ok(url)
+    }
+
+    async fn parse_response(response: reqwest::Response, url: &str) -> Result<Value> {
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!("FXMacroData HTTP {status} for {url}: {body}"));
+        }
+
+        response
+            .json::<Value>()
+            .await
+            .context("failed to parse FXMacroData response")
+    }
+}
+
+pub async fn run_collection(
+    symbols: Vec<String>,
+    writer_tx: UnboundedSender<(DateTime<Utc>, String, String)>,
+) -> Result<()> {
+    let client = FxMacroDataClient::from_env()?;
+
+    emit(
+        &writer_tx,
+        "fxmacrodata_market_sessions",
+        client.market_sessions(&[]).await?,
+    );
+    emit(
+        &writer_tx,
+        "fxmacrodata_risk_sentiment",
+        client.risk_sentiment(&[]).await?,
+    );
+    emit(
+        &writer_tx,
+        "fxmacrodata_commodities_latest",
+        client.commodities_latest(&[]).await?,
+    );
+    emit(
+        &writer_tx,
+        "fxmacrodata_announcement_changes",
+        client.announcement_changes(&[]).await?,
+    );
+
+    for symbol in symbols {
+        if let Some((base, quote)) = parse_pair(&symbol) {
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_{base}{quote}_forex"),
+                client
+                    .forex(&base, &quote, &[("limit", "500".to_string())])
+                    .await?,
+            );
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_{base}{quote}_rate_differentials"),
+                client.rate_differentials(&base, &quote, &[]).await?,
+            );
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_{base}{quote}_forward_differentials"),
+                client.forward_differentials(&base, &quote, &[]).await?,
+            );
+            continue;
+        }
+
+        if let Some((currency, indicator)) = parse_indicator_spec(&symbol) {
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_{currency}_{indicator}_announcements"),
+                client.announcements(&currency, &indicator, &[]).await?,
+            );
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_{currency}_{indicator}_predictions"),
+                client.predictions(&currency, &indicator, &[]).await?,
+            );
+            continue;
+        }
+
+        if let Some(indicator) = parse_commodity_spec(&symbol) {
+            emit(
+                &writer_tx,
+                &format!("fxmacrodata_commodity_{indicator}"),
+                client.commodity(&indicator, &[]).await?,
+            );
+            continue;
+        }
+
+        let currency = normalize_currency(&symbol)?;
+        info!(%currency, "collecting FXMacroData currency context");
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_catalogue"),
+            client.data_catalogue(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_latest_announcements"),
+            client.latest_announcements(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_calendar"),
+            client.calendar(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_cot"),
+            client.cot(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_curves"),
+            client.curves(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_curve_proxies"),
+            client.curve_proxies(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_forward_curves"),
+            client.forward_curves(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_news"),
+            client.news(&currency, &[]).await?,
+        );
+        emit(
+            &writer_tx,
+            &format!("fxmacrodata_{currency}_press_releases"),
+            client.press_releases(&currency, &[]).await?,
+        );
+    }
+
+    Ok(())
+}
+
+fn emit(writer_tx: &UnboundedSender<(DateTime<Utc>, String, String)>, label: &str, data: Value) {
+    let _ = writer_tx.send((Utc::now(), label.to_string(), data.to_string()));
+}
+
+fn parse_pair(symbol: &str) -> Option<(String, String)> {
+    let normalized = symbol
+        .chars()
+        .filter(|c| c.is_ascii_alphabetic())
+        .collect::<String>()
+        .to_lowercase();
+
+    if normalized.len() == 6 {
+        Some((normalized[..3].to_string(), normalized[3..].to_string()))
+    } else {
+        None
+    }
+}
+
+fn parse_indicator_spec(symbol: &str) -> Option<(String, String)> {
+    let (currency, indicator) = symbol.split_once(':')?;
+    if currency.eq_ignore_ascii_case("commodity") {
+        return None;
+    }
+
+    let currency = normalize_currency(currency).ok()?;
+    let indicator = indicator.trim().to_lowercase();
+    if indicator.is_empty() {
+        None
+    } else {
+        Some((currency, indicator))
+    }
+}
+
+fn parse_commodity_spec(symbol: &str) -> Option<String> {
+    let (prefix, indicator) = symbol.split_once(':')?;
+    if !prefix.eq_ignore_ascii_case("commodity") {
+        return None;
+    }
+
+    let indicator = indicator.trim().to_lowercase();
+    if indicator.is_empty() {
+        None
+    } else {
+        Some(indicator)
+    }
+}
+
+fn normalize_currency(currency: &str) -> Result<String> {
+    let normalized = currency.trim().to_lowercase();
+    if normalized.len() == 3 && normalized.chars().all(|c| c.is_ascii_alphabetic()) {
+        Ok(normalized)
+    } else {
+        Err(anyhow!(
+            "FXMacroData symbols must be currencies like usd, pairs like eurusd, or specs like usd:non_farm_payrolls"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_urls_under_api_v1() {
+        let client = FxMacroDataClient::with_base_url("test-key", "https://example.com/api/v1/")
+            .expect("valid base URL");
+        let url = client
+            .build_url("forex/eur/usd", &[("limit", "1".to_string())])
+            .expect("URL should build");
+
+        assert_eq!(
+            url.as_str(),
+            "https://example.com/api/v1/forex/eur/usd?limit=1&api_key=test-key"
+        );
+    }
+
+    #[test]
+    fn parses_currency_pairs() {
+        assert_eq!(
+            parse_pair("EUR/USD"),
+            Some(("eur".to_string(), "usd".to_string()))
+        );
+        assert_eq!(
+            parse_pair("gbpjpy"),
+            Some(("gbp".to_string(), "jpy".to_string()))
+        );
+        assert_eq!(parse_pair("usd"), None);
+    }
+
+    #[test]
+    fn parses_indicator_specs() {
+        assert_eq!(
+            parse_indicator_spec("USD:non_farm_payrolls"),
+            Some(("usd".to_string(), "non_farm_payrolls".to_string()))
+        );
+        assert_eq!(parse_indicator_spec("eurusd"), None);
+        assert_eq!(parse_indicator_spec("commodity:brent"), None);
+    }
+
+    #[test]
+    fn parses_commodity_specs() {
+        assert_eq!(
+            parse_commodity_spec("commodity:brent"),
+            Some("brent".to_string())
+        );
+        assert_eq!(parse_commodity_spec("USD:non_farm_payrolls"), None);
+    }
+}

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -11,6 +11,7 @@ mod binancefuturesum;
 mod bybit;
 mod error;
 mod file;
+mod fxmacrodata;
 mod hyperliquid;
 mod throttler;
 
@@ -103,6 +104,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 writer_tx,
             ))
         }
+        "fxmacrodata" => tokio::spawn(fxmacrodata::run_collection(args.symbols, writer_tx)),
         exchange => {
             return Err(anyhow!("{exchange} is not supported."));
         }

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -1,0 +1,78 @@
+"""Fetch macro-event blackout dates for hftbacktest experiments.
+
+High-frequency strategies often behave differently around scheduled macro
+releases. This helper pulls the FXMacroData public release calendar and creates
+a set of tier-one USD dates that can be used to segment replay results or pause
+new quoting during event windows.
+"""
+
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+import json
+from typing import Any, Dict, Iterable, List, Set
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+
+FXMD_CALENDAR_URL = "https://fxmacrodata.com/api/v1/calendar/{currency}"
+
+
+def fetch_release_events(
+    currency: str,
+    start_date: str,
+    end_date: str,
+) -> List[Dict[str, Any]]:
+    params = urlencode({"start_date": start_date, "end_date": end_date})
+    url = f"{FXMD_CALENDAR_URL.format(currency=currency.upper())}?{params}"
+
+    with urlopen(url, timeout=20) as response:
+        payload = json.load(response)
+
+    return payload.get("data", [])
+
+
+def build_blackout_dates(
+    events: Iterable[Dict[str, Any]],
+    min_market_tier: int = 1,
+    window_days: int = 0,
+) -> Set[str]:
+    blackout_dates: Set[str] = set()
+
+    for event in events:
+        if not event.get("release_date_confirmed"):
+            continue
+
+        market_tier = event.get("market_tier")
+        if market_tier is None or int(market_tier) > min_market_tier:
+            continue
+
+        announcement_ts = event.get("announcement_datetime")
+        if announcement_ts is None:
+            continue
+
+        event_date = datetime.fromtimestamp(
+            int(announcement_ts),
+            tz=timezone.utc,
+        ).date()
+        for offset in range(-window_days, window_days + 1):
+            blackout_dates.add((event_date + timedelta(days=offset)).isoformat())
+
+    return blackout_dates
+
+
+def timestamp_ns_to_date(timestamp_ns: int) -> str:
+    timestamp_seconds = timestamp_ns / 1_000_000_000
+    return datetime.fromtimestamp(timestamp_seconds, timezone.utc).date().isoformat()
+
+
+def can_quote(timestamp_ns: int, blackout_dates: Set[str]) -> bool:
+    return timestamp_ns_to_date(timestamp_ns) not in blackout_dates
+
+
+# Example:
+#
+# events = fetch_release_events("USD", "2026-07-01", "2026-07-31")
+# blackout_dates = build_blackout_dates(events, min_market_tier=1, window_days=0)
+# if not can_quote(hbt.current_timestamp, blackout_dates):
+#     continue

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -12,10 +12,20 @@ from datetime import timezone
 import json
 from typing import Any, Dict, Iterable, List, Set
 from urllib.parse import urlencode
+from urllib.parse import urlparse
+from urllib.request import Request
 from urllib.request import urlopen
 
 
 FXMD_CALENDAR_URL = "https://fxmacrodata.com/api/v1/calendar/{currency}"
+FXMD_HOST = "fxmacrodata.com"
+
+
+def normalize_currency(currency: str) -> str:
+    currency_code = currency.strip().upper()
+    if len(currency_code) != 3 or not currency_code.isalpha():
+        raise ValueError("currency must be a three-letter ISO currency code")
+    return currency_code
 
 
 def fetch_release_events(
@@ -24,9 +34,13 @@ def fetch_release_events(
     end_date: str,
 ) -> List[Dict[str, Any]]:
     params = urlencode({"start_date": start_date, "end_date": end_date})
-    url = f"{FXMD_CALENDAR_URL.format(currency=currency.upper())}?{params}"
+    url = f"{FXMD_CALENDAR_URL.format(currency=normalize_currency(currency))}?{params}"
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != FXMD_HOST:
+        raise ValueError("release calendar URL must use the FXMacroData HTTPS host")
 
-    with urlopen(url, timeout=20) as response:
+    request = Request(url, headers={"User-Agent": "hftbacktest-fxmacrodata-example"})
+    with urlopen(request, timeout=20) as response:  # nosec B310
         payload = json.load(response)
 
     return payload.get("data", [])

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -87,11 +87,3 @@ def timestamp_ns_to_date(timestamp_ns: int) -> str:
 def can_quote(timestamp_ns: int, blackout_dates: Set[str]) -> bool:
     """Return whether a timestamp falls outside the macro-event blackout dates."""
     return timestamp_ns_to_date(timestamp_ns) not in blackout_dates
-
-
-# Example:
-#
-# events = fetch_release_events("USD", "2026-07-01", "2026-07-31")
-# blackout_dates = build_blackout_dates(events, min_market_tier=1, window_days=0)
-# if not can_quote(hbt.current_timestamp, blackout_dates):
-#     continue

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -22,6 +22,7 @@ FXMD_HOST = "fxmacrodata.com"
 
 
 def normalize_currency(currency: str) -> str:
+    """Return a normalized ISO currency code for the FXMacroData API path."""
     currency_code = currency.strip().upper()
     if len(currency_code) != 3 or not currency_code.isalpha():
         raise ValueError("currency must be a three-letter ISO currency code")
@@ -33,6 +34,7 @@ def fetch_release_events(
     start_date: str,
     end_date: str,
 ) -> List[Dict[str, Any]]:
+    """Fetch FXMacroData release-calendar events for a currency and date range."""
     params = urlencode({"start_date": start_date, "end_date": end_date})
     url = f"{FXMD_CALENDAR_URL.format(currency=normalize_currency(currency))}?{params}"
     parsed = urlparse(url)
@@ -51,6 +53,7 @@ def build_blackout_dates(
     min_market_tier: int = 1,
     window_days: int = 0,
 ) -> Set[str]:
+    """Build a set of UTC calendar dates around confirmed macro events."""
     blackout_dates: Set[str] = set()
 
     for event in events:
@@ -76,11 +79,13 @@ def build_blackout_dates(
 
 
 def timestamp_ns_to_date(timestamp_ns: int) -> str:
+    """Convert a nanosecond timestamp to a UTC calendar date string."""
     timestamp_seconds = timestamp_ns / 1_000_000_000
     return datetime.fromtimestamp(timestamp_seconds, timezone.utc).date().isoformat()
 
 
 def can_quote(timestamp_ns: int, blackout_dates: Set[str]) -> bool:
+    """Return whether a timestamp falls outside the macro-event blackout dates."""
     return timestamp_ns_to_date(timestamp_ns) not in blackout_dates
 
 

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -1,4 +1,5 @@
-"""Fetch macro-event blackout dates for hftbacktest experiments.
+"""
+Fetch macro-event blackout dates for hftbacktest experiments.
 
 High-frequency strategies often behave differently around scheduled macro
 releases. This helper pulls the FXMacroData public release calendar and creates

--- a/examples/fxmacrodata_release_calendar_filter.py
+++ b/examples/fxmacrodata_release_calendar_filter.py
@@ -1,11 +1,4 @@
-"""
-Fetch macro-event blackout dates for hftbacktest experiments.
-
-High-frequency strategies often behave differently around scheduled macro
-releases. This helper pulls the FXMacroData public release calendar and creates
-a set of tier-one USD dates that can be used to segment replay results or pause
-new quoting during event windows.
-"""
+"""Fetch macro-event blackout dates for hftbacktest experiments."""
 
 from datetime import datetime
 from datetime import timedelta


### PR DESCRIPTION
## Summary
- keep the FXMacroData release-calendar filtering example
- add a native Rust collector integration for FXMacroData macro, FX, COT, commodities, curves, differentials, sessions, risk sentiment, news, press releases, announcements, predictions, and GraphQL helper access
- support collector symbols for currencies like `usd`, pairs like `eurusd`, indicator specs like `usd:non_farm_payrolls`, and commodities like `commodity:brent`

## Validation
- `cargo test -p collector fxmacrodata`